### PR TITLE
Add dimension 17: Technical debt & legacy stack

### DIFF
--- a/plugins/codebase-audit/README.md
+++ b/plugins/codebase-audit/README.md
@@ -9,7 +9,7 @@ Every grade and finding is backed by a concrete `file:line` pointer so a reviewe
 A single Markdown report (~3–6 pages) written to `reports/{project}_quality_assessment_{YYYY-MM-DD}.md`:
 
 - **Summary stats** — LOC, test LOC, test/code ratio, coverage, commits in last 90 days, active contributors, primary languages
-- **Executive summary** — graded table across 16 dimensions, with a 3–4 sentence bottom line
+- **Executive summary** — graded table across 17 dimensions, with a 3–4 sentence bottom line
 - **Operational picture** — numbered data-flow walkthrough (how the system actually runs)
 - **Per-dimension findings** — each with `file:line` evidence
 - **Substantial problems** — numbered, with effort estimates
@@ -64,6 +64,7 @@ A full sample assessment of a production open-source codebase lives at [`example
 14. Dependency management & supply chain
 15. Frontend bundle & performance
 16. CI/CD execution speed
+17. Technical debt & legacy stack
 
 Grades on a standard A–F scale with `+`/`−` half-steps. Dimensions without enough evidence are marked `—` rather than guessed.
 
@@ -94,7 +95,7 @@ Claude will:
 1. Orient on the project (README, manifests, deploy shape)
 2. Run the stats collector (LOC, coverage artifacts, git activity, CI timing)
 3. Survey operational context (entrypoints, migrations, config, deploy)
-4. Probe each of the 16 dimensions with targeted greps and reads
+4. Probe each of the 17 dimensions with targeted greps and reads
 5. Write the graded report to `reports/`
 
 Typical run: 5–15 minutes on a medium-sized repo.

--- a/plugins/codebase-audit/skills/report/SKILL.md
+++ b/plugins/codebase-audit/skills/report/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: report
-description: Produce a thorough software quality assessment report for a git repository — covering code architecture, security, database design, observability, testing, frontend quality, deployment, disaster recovery, data privacy (GDPR), dependency management, frontend bundle performance, and CI/CD execution speed, plus summary stats (LOC, test LOC, test coverage, commit activity). Use this skill whenever the user asks for a "quality report", "quality assessment", "code audit", "codebase review", "technical due diligence", "production readiness review", "health check", "grade my codebase", or anything along the lines of "how good is this project", "what are the weak spots", "is this safe to deploy", or "assess/audit this repo". Works on any git repo regardless of primary language (Python, TypeScript/JavaScript, Go, Rust, Java, Ruby, PHP, C#, etc.). Writes the report to `reports/{project}_quality_assessment_{YYYY-MM-DD}.md`.
+description: Produce a thorough software quality assessment report for a git repository — covering code architecture, security, database design, observability, testing, frontend quality, deployment, disaster recovery, data privacy (GDPR), dependency management, frontend bundle performance, CI/CD execution speed, and technical debt / legacy-stack currency, plus summary stats (LOC, test LOC, test coverage, commit activity). Use this skill whenever the user asks for a "quality report", "quality assessment", "code audit", "codebase review", "technical due diligence", "production readiness review", "health check", "grade my codebase", or anything along the lines of "how good is this project", "what are the weak spots", "is this safe to deploy", or "assess/audit this repo". Works on any git repo regardless of primary language (Python, TypeScript/JavaScript, Go, Rust, Java, Ruby, PHP, C#, etc.). Writes the report to `reports/{project}_quality_assessment_{YYYY-MM-DD}.md`.
 ---
 
 # Quality Assessment
@@ -101,8 +101,9 @@ At the end of your turn, tell the user:
 14. **Dependency management & supply chain** — Dependabot / Renovate configured, lockfiles committed and verified in CI, `npm audit` / `pip-audit` / equivalent, pinned base images in Dockerfile
 15. **Frontend bundle & performance** *(if a frontend exists)* — production bundle size, code splitting / lazy loading of heavy libs, tree-shaking, source-map discipline, Lighthouse-class red flags
 16. **CI/CD execution speed** — workflow duration, test parallelization (`pytest-xdist`, `vitest --shard`, `go test -parallel`), caching of deps/build artifacts, deploy automation
+17. **Technical debt & legacy stack** — language-runtime currency vs active support windows, framework major-version distance from latest, legacy-language/framework exposure (AngularJS, CoffeeScript, class components in a hooks codebase), upstream maintenance status of direct dependencies (archived / orphaned / last-release staleness), deprecated-API usage, blocked-upgrade signals
 
-Dimensions 12-16 are the ones most commonly missed in ad-hoc code reviews. Treat them as first-class and always include them in the report, even when the answer is "not applicable" (e.g. no frontend → say so in the frontend bundle row).
+Dimensions 12-17 are the ones most commonly missed in ad-hoc code reviews. Treat them as first-class and always include them in the report, even when the answer is "not applicable" (e.g. no frontend → say so in the frontend bundle row).
 
 ## Grading rubric
 
@@ -131,7 +132,7 @@ Full template: `references/report-template.md`. At a high level:
 
 1. **Header table** — date, scope, author, generation method
 2. **Summary Stats** *(new)* — LOC, comment LOC, test LOC, test/code ratio, test coverage, commits in last 90 days, active contributors, primary languages
-3. **Executive Summary** — grade table across all 16 dimensions, plus a 3-4 sentence "bottom line"
+3. **Executive Summary** — grade table across all 17 dimensions, plus a 3-4 sentence "bottom line"
 4. **What the app does — Operational Picture** — numbered data-flow walkthrough, including a "Disaster Recovery & Backups" subsection
 5. **Code Quality Findings** — one subsection per dimension with concrete evidence
 6. **Substantial Problems Worth Addressing** — concrete, numbered, with effort estimates

--- a/plugins/codebase-audit/skills/report/references/dimensions.md
+++ b/plugins/codebase-audit/skills/report/references/dimensions.md
@@ -1,6 +1,6 @@
 # Dimensions Reference
 
-For each of the 16 dimensions, this file lists: what to look for, which probes to run, common evidence patterns, and what pushes the grade up or down.
+For each of the 17 dimensions, this file lists: what to look for, which probes to run, common evidence patterns, and what pushes the grade up or down.
 
 Read only the sections for dimensions you're currently assessing. You do not need to load this file upfront.
 
@@ -437,3 +437,62 @@ If no frontend: `— N/A`.
 - Long tests without sharding.
 
 **How to report timing when you can't measure directly:** say so. "Could not run `gh run list` in this environment; workflow structure suggests roughly N minutes based on steps." Being explicit about the limitation is better than inventing a number.
+
+---
+
+## 17. Technical debt & legacy stack
+
+**Question:** Is the tech stack still alive — language runtimes on supported versions, frameworks within reach of latest, load-bearing dependencies still maintained upstream — or is the team accumulating a migration backlog they haven't acknowledged?
+
+This dimension is orthogonal to §14. §14 asks whether the *update process* is wired up (Dependabot, lockfiles, CVE scans). §17 asks what version you are *actually on right now*, and whether the upstream projects you depend on are still alive. A project can have excellent Dependabot automation and still be on Python 3.7 with a pile of archived npm packages. Grade them independently.
+
+**Probes:**
+- **Primary language runtime version** vs the language's current support window:
+  - Python: `requires-python` in `pyproject.toml`, `python_requires` in `setup.py`, `.python-version`, `runtime.txt`. Compare to the CPython support matrix (`3.9` is the current floor as of writing; anything older is EOL).
+  - Node: `engines.node` in `package.json`, `.nvmrc`, `.node-version`, CI setup-node version. Compare to the active LTS line (Node 20 / 22 are active; 18 and below are EOL or entering EOL).
+  - Go: `go` directive in `go.mod`. Go supports the last two minors only.
+  - Ruby: `.ruby-version`, `Gemfile`'s `ruby` directive.
+  - Java / Kotlin: JDK version in `build.gradle` / `pom.xml`. Compare to current LTS (21, 17).
+  - .NET: `TargetFramework` in `*.csproj`. Compare to .NET current LTS.
+  - PHP: `require.php` in `composer.json`. Compare to supported PHP branches.
+  - Rust: `rust-toolchain` / `rust-toolchain.toml`. Rust's MSRV policy is looser — "at least six months old" is fine.
+- **Framework major versions** vs latest major release. Cross-reference `package.json`, `pyproject.toml`, `Gemfile`, `composer.json`, `pom.xml`, etc. against the current major — React (19), Next.js (15), Angular, Vue (3), Django (5), FastAPI, Flask (3), Spring Boot (3), Rails (7/8), Laravel (11), Symfony (7), Express (5), .NET (9). Two-plus majors behind is a finding.
+- **Datastore / infra majors** from Docker / compose / README: PostgreSQL, MySQL, Redis, Elasticsearch / OpenSearch. Check against upstream supported-versions pages.
+- **Legacy-technology exposure.** Anything load-bearing in a technology the rest of the industry has moved off: AngularJS 1.x, CoffeeScript, Backbone, Ember pre-3, jQuery in a modern SPA codebase, moment.js, class components in an otherwise-hooks React codebase, Python 2 compat shims, Flow types alongside (or instead of) TypeScript.
+- **Dependency maintenance status** — is every direct dependency's upstream still alive? For 30+ direct deps, per-dep lookups aren't tractable — lean on **bulk ecosystem signals** instead of maintaining a curated list:
+  - **Registry deprecation warnings** — one command per ecosystem, authoritative. Node: `npm outdated` + `npm ls` surface packages the maintainer flagged deprecated. Python: `pip-audit` + `pip list --outdated`. Rust: `cargo outdated`. Go: `go list -m -u all`. Ruby: `bundle outdated`. PHP: `composer outdated --direct`.
+  - **Last-release age.** The same `outdated` commands plus `npm view <pkg> time` / `pip index versions <pkg>` give last-publish dates. Flag any direct dep with no release in > 18 months.
+  - **PyPI `Development Status` classifier.** Machine-readable from package metadata; `Development Status :: 7 - Inactive` is an explicit abandonment signal.
+  - **GitHub `archived: true`.** Authoritative per-repo flag. For suspicious deps surfaced by the steps above, `gh api repos/{owner}/{repo} --jq .archived` settles it in one call.
+  - **Lockfile staleness.** If the lockfile churns frequently but a specific dep's resolved version hasn't moved in 3+ years (`git log -p -- package-lock.json | grep <pkg>`), the upstream has likely stalled.
+  - **Known-orphan examples, for calibration only** (not a checklist — verify with the signals above): `request` → `undici`; `moment` → `date-fns` / `Temporal`; `node-sass` → `sass`; `tslint` → `eslint`; `enzyme` → `@testing-library/react`; `bower`, `gulp` in many SPA contexts.
+
+  Flag each unmaintained load-bearing dep individually with last-release date and canonical successor where one exists. Security-sensitive unmaintained deps (HTTP clients, crypto, auth) are heavier findings than benign ones (a logging helper).
+- **Deprecated APIs in active use.** `componentWillMount` / `componentWillReceiveProps`, legacy React context, `PropTypes` on new components, Python 2 compat imports, `asyncio.get_event_loop()` in 3.12+ code, Django `url()` instead of `path()`, Rails `before_filter`, etc.
+- **Build tooling currency.** webpack 4 vs 5 / Vite / Turbopack; Babel 6 vs 7; setuptools-only vs uv / poetry / hatch; plain `npm` vs `pnpm` / `yarn` for large monorepos; Make vs Bazel / Nx where complexity demands it.
+- **Blocked-upgrade signals.** Grep the repo for comments like `# do not bump`, `// locked to 4.x`, `# can't upgrade because`, TODOs referencing a stuck dep, issues labeled `upgrade-blocker`. These are the debt the team already knows about.
+
+**Pushes grade up:**
+- All runtimes on active LTS / actively supported versions.
+- Frameworks within one major of latest, or on the latest LTS for frameworks that ship LTS lines.
+- No load-bearing legacy technology.
+- Every direct dependency released within the last ~12 months (or has a clear long-term-stable signal, e.g., `lodash` — mature, stable, still maintained).
+- Documented upgrade intent in CHANGELOG / README / issues — even as TODOs — showing the team tracks major versions.
+
+**Pushes grade down:**
+- Language runtime EOL or entering EOL in < 12 months (Python < 3.9, Node ≤ 18 post-EOL, PHP < 8.2, Go more than two minors behind, .NET on a non-LTS past its support window).
+- A major framework two or more majors behind (React 16 with 19 out, Angular 1.x, Django 3.x with 5 out, Rails 5.x, Laravel 7).
+- Load-bearing legacy technology with no migration plan (AngularJS, CoffeeScript, Flash, Silverlight).
+- Direct dependencies whose upstream is archived / unmaintained / last-released > 18 months ago, with no migration plan — especially security-sensitive ones.
+- Pinned-forever dependencies with `# do not bump` and no replacement plan.
+- Deprecated APIs mixed into *new* code (old patterns added in the last 90 days).
+
+**Calibration:**
+- **A** — everything current, no legacy corners, every direct dep actively maintained.
+- **A−** — one acknowledged outlier with a migration plan (e.g., "one AngularJS admin page, ticket #234 to rewrite in React").
+- **B** — a couple of majors behind on a framework or two, all runtimes still supported, no archived deps.
+- **C** — runtime approaching EOL, or one archived security-sensitive dep still in use, or a load-bearing legacy area with no plan.
+- **D** — runtime already EOL, or multiple archived deps, or AngularJS 1.x still load-bearing with no migration.
+- **F** — stack is effectively unmaintainable; a new hire would need to learn an obsolete language or framework to contribute.
+
+If the project is brand-new (initial commit < 6 months ago) and everything is current, grade A on the state *now* but note that §17 will need re-evaluation annually — this dimension drifts on its own.

--- a/plugins/codebase-audit/skills/report/references/report-template.md
+++ b/plugins/codebase-audit/skills/report/references/report-template.md
@@ -59,6 +59,7 @@ If any row is `Not measured` or approximate, say why in the Notes column. Do not
 | Dependency management | **{grade}** | {one line — "Dependabot active" or "No automation detected"} |
 | Frontend bundle / perf | **{grade or `— N/A`}** | {one line or N/A reason} |
 | CI/CD execution speed | **{grade}** | {one line — include observed duration if measurable} |
+| Technical debt / legacy stack | **{grade}** | {one line — e.g., "Python 3.12, Node 20 LTS, React 19, no archived deps" or "Python 3.8 EOL; Django 3.2 two majors behind; `request` (archived) still in use"} |
 
 **Bottom line:** {3-5 sentences. Lead with the overall verdict (production-grade / healthy with gaps / needs work before launch). Name 1-2 standout strengths. Name the top 1-2 weakest dimensions. Close with "remaining work is [refinement / rescue / closing a specific gap]".}
 
@@ -179,6 +180,16 @@ If no frontend exists: `— N/A: backend-only service`.
 - **Matrix / sharding:** {tests split across jobs?}
 - **Deploy automation:** {manual `workflow_dispatch` / auto on push / tagged releases only}
 
+### 4.17 Technical debt and legacy stack
+
+- **Language runtime versions:** {e.g., "Python 3.12 (`requires-python = ">=3.12"` in `pyproject.toml`), Node 20 LTS (`engines.node = ">=20"` in `package.json`)" — or flag: "Python 3.8 (`.python-version:1`) — EOL October 2024"}
+- **Framework majors vs latest:** {e.g., "React 19, Next.js 15, FastAPI latest" — or flag: "React 16 (two majors behind current 19); Django 3.2 (two LTS lines behind)"}
+- **Legacy-technology exposure:** {list anything load-bearing in a legacy tech — AngularJS, CoffeeScript, jQuery in a modern SPA, moment.js, class components in a hooks codebase — or "None detected"}
+- **Dependency maintenance status:** {name the bulk check you ran (`npm outdated` + `npm ls` for Node, `pip list --outdated` + `pip-audit` for Python, `cargo outdated`, `bundle outdated`, `composer outdated --direct`, `go list -m -u all`) and summarize what it surfaced. List any direct dep that is registry-deprecated, archived on GitHub (`archived: true`), classified PyPI `Development Status :: 7 - Inactive`, or last-released > 18 months ago — with canonical successor where one exists, e.g., "`request` (archived 2020 → `undici`)", "`moment` (maintenance-only → `date-fns` / `Temporal`)". "No unmaintained direct dependencies detected via `npm outdated` + archive spot-check" if clean.}
+- **Deprecated APIs in use:** {e.g., `componentWillMount`, `asyncio.get_event_loop()` in 3.12+, Django `url()`, Rails `before_filter` — or "None in new code"}
+- **Build tooling currency:** {e.g., "Vite 5, uv, pnpm" — or flag: "webpack 4 (webpack 5 has been out since 2020)"}
+- **Blocked upgrades:** {grep for `# do not bump`, `// locked to`, upgrade-blocker TODOs; list each with the reason if stated}
+
 ---
 
 ## 5. Substantial Problems Worth Addressing
@@ -232,7 +243,7 @@ N+1. ...
 
 - The **Summary Stats** table (§1) is new — older reports didn't have it. Always include it, even when numbers are approximate. Mark approximations in the Notes column.
 - The **Disaster Recovery & Backups subsection** (§3) is mandatory. If you cannot find evidence of a backup strategy, say so explicitly — do not omit the subsection.
-- The **dimension grade table** (§2) must include all 16 dimensions, including the newer ones (12-16). Use `— N/A` with a reason for rows that don't apply to this project type.
+- The **dimension grade table** (§2) must include all 17 dimensions, including the newer ones (12-17). Use `— N/A` with a reason for rows that don't apply to this project type.
 - When a dimension is listed in the executive summary table, it must have a corresponding subsection in §4. Do not grade something in §2 and then skip it in §4.
 - Section 5 items should be actionable. "Improve observability" is not actionable; "Add `sentry_sdk.set_context()` at the top of the 4 long-running service entry points, ≈ 1 hour" is.
 - Section 7's medium-term bucket should mention Dependabot / Renovate explicitly if the project lacks automated dependency updates.


### PR DESCRIPTION
## Summary

- Adds a 17th audit dimension covering language-runtime currency, framework major-version distance, legacy-technology exposure, and upstream maintenance status of direct dependencies.
- Orthogonal to §14 (Dependency management) — §14 asks whether the update *process* is wired up (Dependabot, lockfiles, CVE scans); §17 asks what version you're actually running and whether the upstream is still alive. A project can have excellent Dependabot and still be on EOL Python with archived deps.
- Dependency-maintenance check leans on bulk ecosystem commands (`npm outdated`, `pip list --outdated`, `cargo outdated`, `bundle outdated`, `go list -m -u all`) plus GitHub's `archived` flag and PyPI's `Development Status` classifier — no curated allowlist to maintain.
- Updates touch: `dimensions.md` (new §17), `SKILL.md` (summary bullet + counts), `report-template.md` (new grade-table row + §4.17), `README.md` (list + counts).

## Test plan

- [ ] `rg "16 dimension" plugins/codebase-audit` returns zero hits
- [ ] `rg "Dimensions 12-16" plugins/codebase-audit` returns zero hits
- [ ] `dimensions.md` `## N.` headers run 1–17 consecutively
- [ ] `report-template.md` `### 4.N` headers run 4.1–4.17 consecutively
- [ ] Executive-summary grade table in `report-template.md` has 17 data rows
- [ ] Smoke test: run the skill against a small repo and confirm the output contains 17 rows in §2 and a populated §4.17

🤖 Generated with [Claude Code](https://claude.com/claude-code)