### PR TITLE
Release codebase-audit v0.2.0

### DIFF
--- a/plugins/codebase-audit/.claude-plugin/plugin.json
+++ b/plugins/codebase-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codebase-audit",
   "description": "Produces a thorough software quality assessment report for a git repository — architecture, security, database design, observability, testing, DR, GDPR, dependencies, frontend bundle, and CI/CD speed. Evidence-based grading with file:line citations.",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "author": {
     "name": "Adrian Imfeld",
     "email": "aimfeld80@gmail.com"

--- a/plugins/codebase-audit/CHANGELOG.md
+++ b/plugins/codebase-audit/CHANGELOG.md
@@ -1,0 +1,20 @@
+# Changelog
+
+All notable changes to the `codebase-audit` plugin are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [Semantic Versioning](https://semver.org/).
+
+## [0.2.0] — 2026-04-17
+
+### Added
+- **Dimension 17 — Technical debt & legacy stack.** Grades language-runtime currency, framework major-version distance, legacy-technology exposure, and upstream maintenance status. ([#2](https://github.com/aimfeld/claude-plugins/pull/2))
+
+### Changed
+- **Database FK cascade check** now probes DB-level migrations (constraint DDL) before flagging ORM-level cascade gaps, reducing false positives on codebases where referential actions are defined in SQL rather than the ORM. ([#1](https://github.com/aimfeld/claude-plugins/pull/1))
+- **GDPR data-erasure guidance** refined to give the report a clearer stance on acceptable erasure designs. ([#1](https://github.com/aimfeld/claude-plugins/pull/1))
+
+## [0.1.0]
+
+### Added
+- Initial release: 16-dimension quality assessment skill with evidence-based grading and `file:line` citations.
+
+[0.2.0]: https://github.com/aimfeld/claude-plugins/releases/tag/codebase-audit-v0.2.0
+[0.1.0]: https://github.com/aimfeld/claude-plugins/releases/tag/codebase-audit-v0.1.0

--- a/plugins/codebase-audit/README.md
+++ b/plugins/codebase-audit/README.md
@@ -75,6 +75,16 @@ Grades on a standard A–F scale with `+`/`−` half-steps. Dimensions without e
 /plugin install codebase-audit@aimfeld
 ```
 
+## Updating
+
+Claude Code refreshes marketplaces automatically at startup, so new versions are usually picked up next time you launch it. To pull the latest version on demand, run:
+
+```
+/plugin marketplace update aimfeld
+```
+
+See [CHANGELOG.md](./CHANGELOG.md) for what's in each release.
+
 ## Use
 
 This skill is model-invoked — just ask naturally:


### PR DESCRIPTION
## Summary

Publishes the changes from #1 and #2 as **codebase-audit v0.2.0**. Bumping `plugin.json`'s `version` is what tells Claude Code marketplace clients to pull the new content (same-version commits get treated as identical and skipped).

## What's in the release

### Added
- **Dimension 17 — Technical debt & legacy stack** (runtime currency, framework major-version distance, legacy-tech exposure, upstream maintenance). (#2)

### Changed
- DB FK cascade check now probes DB-level constraint DDL before flagging ORM-level cascade gaps. (#1)
- GDPR data-erasure design guidance refined. (#1)

## Files

- `plugins/codebase-audit/.claude-plugin/plugin.json` — `0.1.0` → `0.2.0`
- `plugins/codebase-audit/CHANGELOG.md` — new file, Keep-a-Changelog format, seeded with 0.1.0 and 0.2.0 entries
- `plugins/codebase-audit/README.md` — new "Updating" section pointing at `/plugin marketplace update aimfeld`

## How updates reach users after merge

- Claude Code runs background marketplace updates at startup, so most users will pick this up on their next session.
- On-demand: `/plugin marketplace update aimfeld`.

## After-merge follow-up (not automated yet)

- Tag `codebase-audit-v0.2.0` on the merge commit and publish a GitHub release with the CHANGELOG excerpt.

## Test plan

- [ ] After merge: `/plugin marketplace update aimfeld` — should detect v0.2.0
- [ ] `/plugin` menu shows `codebase-audit` at `0.2.0`
- [ ] Running the report skill on a throwaway repo produces a report that includes the new **Dimension 17** section

🤖 Generated with [Claude Code](https://claude.com/claude-code)