### PR TITLE
Correct update-propagation docs: third-party auto-update is off by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,10 +15,14 @@ Paths in `marketplace.json` resolve relative to the marketplace root (the direct
 ## How a release actually reaches users
 
 - Marketplace clients cache by **plugin version**. If two commits share the same `plugin.json` version, Claude Code treats them as identical and skips the update. **Bumping `version` is what publishes a release.** No bump, no propagation.
-- `version` lives in `plugins/<name>/.claude-plugin/plugin.json` only. Do not also set it in the marketplace entry — `plugin.json` silently wins and a split version is a footgun. (The upstream docs suggest putting it in `marketplace.json` for relative-path plugins; in practice `plugin.json`-only works fine and keeps one source of truth.)
-- After the tagged release lands on `main`, users pick it up two ways:
-  - **Auto:** Claude Code runs a background marketplace update at startup.
-  - **Manual:** `/plugin marketplace update aimfeld`.
+- `version` lives in `plugins/<name>/.claude-plugin/plugin.json` only. Do not also set it in the marketplace entry — `plugin.json` silently wins and a split version is a footgun. (From the reference docs: *"If also set in the marketplace entry, `plugin.json` takes priority. You only need to set it in one place."*)
+- **Third-party marketplaces have auto-update OFF by default.** From the docs: *"Official Anthropic marketplaces have auto-update enabled by default. Third-party and local development marketplaces have auto-update disabled by default."* This is a per-user, per-marketplace toggle — there is **no way** for a marketplace author to flip this default for consumers. Users must enable it themselves in `/plugin` → Marketplaces → `aimfeld` → Enable auto-update.
+- After a tagged release lands on `main`, users pick it up in one of three ways:
+  - **Auto-update, opted in:** Claude Code refreshes the marketplace at startup and updates installed plugins. When something actually updated, the user is prompted to run `/reload-plugins`.
+  - **Manual, on demand:** `/plugin marketplace update aimfeld` followed by `/reload-plugins`.
+  - **Fresh install:** `/plugin install codebase-audit@aimfeld` picks up the current version.
+- **Native marketplace auto-update requires Claude Code ≥ 2.0.70.** Older clients can only update manually.
+- **There are known bugs in the update path** (tracked upstream): stale marketplace clones not fast-forwarding, installed plugin not actually reloading after marketplace update, npm-sourced plugins using stale caches, etc. Expect the occasional report of "I ran update but nothing changed" — workaround is usually `rm -rf ~/.claude/plugins/cache/aimfeld && /plugin marketplace update aimfeld` and then a Claude Code restart. See upstream issues [#26744](https://github.com/anthropics/claude-code/issues/26744), [#17361](https://github.com/anthropics/claude-code/issues/17361), [#29071](https://github.com/anthropics/claude-code/issues/29071), [#46594](https://github.com/anthropics/claude-code/issues/46594).
 
 ## Release playbook
 

--- a/plugins/codebase-audit/README.md
+++ b/plugins/codebase-audit/README.md
@@ -77,13 +77,23 @@ Grades on a standard A–F scale with `+`/`−` half-steps. Dimensions without e
 
 ## Updating
 
-Claude Code refreshes marketplaces automatically at startup, so new versions are usually picked up next time you launch it. To pull the latest version on demand, run:
+Third-party marketplaces have auto-update **disabled by default** in Claude Code — only the official Anthropic marketplace auto-updates out of the box. To receive new versions of this plugin automatically, turn auto-update on once:
+
+1. Run `/plugin`
+2. Go to the **Marketplaces** tab
+3. Select `aimfeld`
+4. Choose **Enable auto-update**
+
+After that, Claude Code will refresh the marketplace at startup and update the plugin. When a plugin changes, you'll be prompted to run `/reload-plugins` to activate the new version.
+
+To update on demand (works whether or not auto-update is on):
 
 ```
 /plugin marketplace update aimfeld
+/reload-plugins
 ```
 
-See [CHANGELOG.md](./CHANGELOG.md) for what's in each release.
+Requires Claude Code ≥ 2.0.70 for native marketplace auto-update. See [CHANGELOG.md](./CHANGELOG.md) for what's in each release.
 
 ## Use
 


### PR DESCRIPTION
## Summary

After v0.2.0 didn't propagate to a new session, research into the docs revealed why: **third-party marketplaces have auto-update disabled by default.** Only the official Anthropic marketplace auto-updates out of the box, and there is no field in \`marketplace.json\` that a marketplace author can set to change this. Users must opt in per marketplace.

Fixes the too-optimistic \"picks up automatically at startup\" framing in \`CLAUDE.md\` and expands the plugin README to walk the user through the one-time opt-in plus a manual fallback.

## Changes

- \`CLAUDE.md\` — state the third-party default with a direct quote from the docs, note the one-time opt-in path, cite the Claude Code 2.0.70 version floor, and link known upstream bugs in the update path.
- \`plugins/codebase-audit/README.md\` — replace the one-liner Updating section with:
  - Four-step **Enable auto-update** instructions (one-time)
  - Manual fallback using \`/plugin marketplace update aimfeld\` + \`/reload-plugins\`
  - Version floor note

## Why no version bump

This is a docs-only change. Bumping \`plugin.json\` would invalidate plugin caches for users who have auto-update on — pointless churn for content that isn't in the installed plugin anyway.

## Sources

- [Discover and install plugins — Configure auto-updates](https://code.claude.com/docs/en/discover-plugins#configure-auto-updates)
- [Plugins reference — Version management](https://code.claude.com/docs/en/plugins-reference#version-management)
- Upstream bugs: [#26744](https://github.com/anthropics/claude-code/issues/26744), [#17361](https://github.com/anthropics/claude-code/issues/17361), [#29071](https://github.com/anthropics/claude-code/issues/29071), [#46594](https://github.com/anthropics/claude-code/issues/46594)

## Test plan

- [ ] Fresh Claude Code session on a machine that already has the plugin installed: follow the README \"Enable auto-update\" steps, restart, verify the marketplace clone's \`lastUpdated\` advances.
- [ ] Same machine, run \`/plugin marketplace update aimfeld\` and confirm it works as the manual fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)