### PR TITLE
Release codebase-audit v0.4.0 — environment-tier-aware audits

### DIFF
--- a/plugins/codebase-audit/.claude-plugin/plugin.json
+++ b/plugins/codebase-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codebase-audit",
   "description": "Produces a thorough software quality assessment report for a git repository — architecture, security, database design, observability, testing, DR, GDPR, dependencies, frontend bundle, and CI/CD speed. Evidence-based grading with file:line citations.",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": {
     "name": "Adrian Imfeld",
     "email": "aimfeld80@gmail.com"

--- a/plugins/codebase-audit/CHANGELOG.md
+++ b/plugins/codebase-audit/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to the `codebase-audit` plugin are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [Semantic Versioning](https://semver.org/).
 
+## [0.4.0] — 2026-04-18
+
+### Added
+- **Environment-tier verdict from `collect_stats.sh`.** The script now ends with a grep-able `ENVIRONMENT_TIER: warm|partial|cold` line plus per-signal flags (`SIGNAL_LOC_TOOL`, `SIGNAL_TEST_RUNNER_DETECTED`, `SIGNAL_TEST_DEPS_INSTALLED`) so the skill can tell whether the audit was run from a warm active-dev environment, a partially-equipped one, or a cold clone with no tooling — and branch accordingly. ([#8](https://github.com/aimfeld/claude-plugins/pull/8))
+- **Single install-or-skip decision (Step 2b.1a in `SKILL.md`).** When the environment tier is `partial`, the skill asks *once* whether to install missing deps, run only what's already runnable, or skip Step 2b entirely — quoting commands from the repo's own docs (README, Makefile, package.json scripts) rather than guessing. Replaces what would previously have been N per-suite permission prompts. ([#8](https://github.com/aimfeld/claude-plugins/pull/8))
+- **Section-level assessability vocabulary in the report template.** Method & Limitations block now distinguishes claim-level confidence (Verified / Likely / Inferred, unchanged) from section-level assessability (`Measured` / `Inferred from artifacts` / `Not assessable without setup`). Cold-clone reports degrade explicitly — §1 rows state what tooling would be needed to upgrade the row to Measured, and §5 caps the confidence of findings sourced from Not-assessable sections at Inferred. ([#8](https://github.com/aimfeld/claude-plugins/pull/8))
+
+### Fixed
+- **`collect_stats.sh` portability.** Added a bash 4+ version guard (fails loudly with a macOS-specific `brew install bash` hint instead of emitting a cryptic syntax error under bash 3.2). Output path now respects `$TMPDIR` for sandboxed/containerized environments. ([#8](https://github.com/aimfeld/claude-plugins/pull/8))
+- **`collect_stats.sh` backup-evidence grep.** Replaced the GNU-only `grep -rlI --exclude-dir=…` with a portable `find -prune … -print0 | xargs -0 grep -lEi` pipeline that works across GNU grep, BSD grep (macOS), and busybox. ([#8](https://github.com/aimfeld/claude-plugins/pull/8))
+- **`collect_stats.sh` test-LOC word-splitting.** Rewrote `for d in $(… | sort -u)` as `while IFS= read -r d; do …; done < <(…)` so test-directory paths containing spaces are counted correctly instead of silently skipped. ([#8](https://github.com/aimfeld/claude-plugins/pull/8))
+- **`collect_stats.sh` `gh run list` error masking.** Routed the `gh run list` call through a temp file and inspected its exit code via `PIPESTATUS`-equivalent pattern — previously `tee` masked `gh` failures behind its own success, silently producing an empty "no recent runs" result rather than telling the reader `gh` couldn't ask. ([#8](https://github.com/aimfeld/claude-plugins/pull/8))
+
 ## [0.3.0] — 2026-04-18
 
 ### Added
@@ -40,6 +53,7 @@ All notable changes to the `codebase-audit` plugin are documented here. Format f
 ### Added
 - Initial release: 16-dimension quality assessment skill with evidence-based grading and `file:line` citations.
 
+[0.4.0]: https://github.com/aimfeld/claude-plugins/releases/tag/codebase-audit-v0.4.0
 [0.3.0]: https://github.com/aimfeld/claude-plugins/releases/tag/codebase-audit-v0.3.0
 [0.2.1]: https://github.com/aimfeld/claude-plugins/releases/tag/codebase-audit-v0.2.1
 [0.2.0]: https://github.com/aimfeld/claude-plugins/releases/tag/codebase-audit-v0.2.0

--- a/plugins/codebase-audit/skills/report/SKILL.md
+++ b/plugins/codebase-audit/skills/report/SKILL.md
@@ -45,6 +45,12 @@ If `tokei` is not installed, the script will ask whether to install it. Tokei gi
 
 Test coverage: the script looks for existing coverage artifacts (`.coverage`, `coverage.xml`, `lcov.info`, `coverage/coverage-summary.json`, `htmlcov/`, Go coverprofile, etc.). It does **not** run tests by itself — if no artifact exists, report coverage as "not measured" and proceed to Step 2b (optional test run) before falling back to "not measured".
 
+**Environment tier.** The script ends with an `ENVIRONMENT_TIER: warm|partial|cold` line plus per-signal flags (`SIGNAL_LOC_TOOL`, `SIGNAL_TEST_RUNNER_DETECTED`, `SIGNAL_TEST_DEPS_INSTALLED`). Read these before Step 2b — they decide the branch you take and the "Environment tier" row in the report's Method & Limitations block. The tiers:
+
+- **warm** — an LOC tool is on PATH AND at least one detected test runner has its deps installed. Run tests per suite with user approval.
+- **partial** — the environment is missing at least one capability (LOC tool absent, OR test runners detected but deps not installed, OR no test runners in a language where the audit usually has them). Ask the user *once* (Step 2b.1a below) whether to install, skip-but-run-what's-possible, or skip Step 2b entirely. Do not ask per suite.
+- **cold** — no LOC tool AND no runner with installed deps. Skip Step 2b; mark dynamic-validation rows in §1 as `Not assessable without setup` and name the missing tooling.
+
 ### 2b. Offer to run the test suite *(optional)*
 
 This step turns a pure-static report into one with dynamic-validation data points — one per test suite in the project. It is **opt-in per suite** — always ask the user first, and skip cleanly when dependencies are not installed or the project's test commands aren't discoverable.
@@ -60,6 +66,23 @@ Read these, in order, before proposing anything:
 3. The README sections the hints surfaced (e.g., "Running Tests", "Test Coverage") — read those lines in the README directly, don't paraphrase.
 4. For a Python project: whether `uv.lock` / `poetry.lock` / `Pipfile.lock` is present (influences the runner prefix: `uv run pytest` vs `.venv/bin/pytest` vs `poetry run pytest`).
 5. For a monorepo: treat each suite separately (e.g., backend `pytest`, frontend `vitest`). Each gets its own row in §1 and its own pass/fail + coverage number.
+
+#### Step 2b.1a — Environment-tier gate (one question, not per-suite)
+
+Before proposing individual suites, branch on `ENVIRONMENT_TIER` from the stats output. This consolidates what would otherwise be N install-or-skip prompts into a single decision — the audit stays a conversation, not an interrogation.
+
+- **`warm`** — deps are installed for at least one suite. Proceed directly to Step 2b.2 and ask per-suite Run/Skip as before. No consolidated question needed.
+
+- **`partial`** — at least one gap. Compose the install plan *from the repo's own docs* (the README "Running Tests" section the stats script surfaced, the Makefile / Taskfile target, the `package.json` script — **do not guess commands**), then ask the user once via `AskUserQuestion` with these options:
+  - **Install missing deps, then run tests** — list the exact commands you would run (e.g., `cd frontend && npm install`, `composer install`, `uv sync`). Cite the source of each command (README line, Makefile target, script name). If no documented command exists for a gap, say so and do not offer to install it.
+  - **Skip install, run only suites whose deps are already installed** — proceed to Step 2b.2 but silently mark the non-runnable suites as `Not executed (deps not installed)` in §1.
+  - **Skip Step 2b entirely** — mark all dynamic-validation rows as `Not executed (user declined)` and continue to Step 3.
+
+  If the user picks "Install", run the quoted commands (with permission) in the target repo, then re-run `collect_stats.sh` to refresh the tier — do not assume install succeeded, verify by reading the new tier line. If the re-run still reports `partial`, note which suites are still blocked and proceed with what's runnable.
+
+- **`cold`** — nothing dynamic can be measured. Skip Step 2b entirely. Mark every dynamic-validation row in §1 as `Not assessable without setup` with the tier reason (copy from `TIER_REASON` in the stats output). The Method & Limitations block's "Environment tier" row records this so the reader knows the audit's envelope up front.
+
+The single install-or-skip question is the only install prompt for the whole audit. Do not re-ask per suite in Step 2b.2.
 
 #### Step 2b.2 — Propose commands to the user
 
@@ -132,7 +155,7 @@ Use the exact structure in `references/report-template.md`. Fill each section wi
 
 **Author field.** Read `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json` and substitute the `version` field into the Author row, producing e.g. `Claude (Opus 4.7) via the codebase-audit:report skill (v0.3.0)`. Every saved report must carry the plugin version so readers can tell which revision of the skill produced it.
 
-**Method & Limitations block.** Mandatory. Sits between the Context paragraph and §1 Summary Stats. Fill the "Dynamic validation" line based on whether Step 2b ran — pass/fail + coverage if it did, "No tests were run" otherwise. Do not paraphrase the grade rubric; copy it from the template verbatim so the ladder is consistent across reports.
+**Method & Limitations block.** Mandatory. Sits between the Context paragraph and §1 Summary Stats. Fill the "Dynamic validation" line based on whether Step 2b ran — pass/fail + coverage if it did, "No tests were run" otherwise. Also fill the "Environment tier" line by copying the `ENVIRONMENT_TIER` value and `TIER_REASON` from the stats output; for a `cold` or `partial` tier, this line tells the reader which rows in §1 are `Not assessable without setup` and why. Do not paraphrase the grade rubric; copy it from the template verbatim so the ladder is consistent across reports.
 
 **Findings Register (§5).** Mandatory. Populate with 10–25 rows drawn from §4 subsections — only findings a reviewer would actually file as a ticket. Every row needs Severity × Confidence × Evidence × Effort. Every Critical and High row must reappear in §6 Substantial Problems. This is the single most important addition over older report versions — it reframes narrative into a register a PM can triage.
 

--- a/plugins/codebase-audit/skills/report/references/report-template.md
+++ b/plugins/codebase-audit/skills/report/references/report-template.md
@@ -28,16 +28,27 @@ Save the filled-in report to `reports/{project-name}_quality_assessment_{YYYY-MM
 
 **What this is not.** Not a formal audit. No interviews with the development team. No legal or professional accountability. No ISO 25010 weighted-scoring methodology. No dynamic penetration testing or load testing. Use this as a first-pass engineering review, not as a substitute for an investor-grade or compliance-grade assessment.
 
-**Confidence levels.** Each finding in the §5 Findings Register is tagged with one of three confidence levels:
+**Confidence levels.** Each finding in the §5 Findings Register is tagged with one of three confidence levels (applies to individual *claims*):
 
 - **Verified** — claim backed by end-to-end reading of the cited file(s).
 - **Likely** — claim backed by spot-check of representative files, or strongly implied by configuration.
 - **Inferred** — claim backed by absence of contrary evidence (e.g., "no `.github/workflows/` found → no CI"). Inferred ≠ wrong, but is the most likely to miss something the repo's maintainers know that the static analysis cannot see.
 
+**Section assessability.** Each row in §1 Summary Stats carries one of three assessability tiers (applies to *whole sections* — a step above claim-level confidence):
+
+- **Measured** — we ran the tool or parsed the artifact (e.g., coverage artifact exists and was read; tests were executed).
+- **Inferred from artifacts** — we read configs and lockfiles but didn't execute anything (e.g., "Dependabot configured" from `.github/dependabot.yml` presence; "Maintainability-test design" from test-file shape without running them).
+- **Not assessable without setup** — the probe requires tooling or deps that aren't installed in this environment. State what *would* be needed to upgrade the row to Measured (e.g., "install `node_modules/` then re-run with `SIGNAL_TEST_DEPS_INSTALLED=yes`").
+
+A finding sourced from a "Not assessable" section must not exceed **Inferred** in §5.
+
+**Environment tier.** {Copy the `ENVIRONMENT_TIER` value and `TIER_REASON` from `collect_stats.sh` output — e.g., "warm — LOC tool on PATH and at least one test runner has its deps installed." / "partial — test runners detected but deps not installed." / "cold — no LOC tool on PATH and no test runner with installed deps." This line tells the reader which §1 rows will read as `Not assessable without setup`.}
+
 **Dynamic validation.** {One of:
 - "No tests were run; the Maintainability grade reflects static inspection of the test suite only."
 - "Backend suite: {N passed / M total}, coverage {X%}. Frontend suite: {N passed / M total}, coverage {X%}. Per-suite details in §1 Summary Stats. Results are separate from the Maintainability grade, which reflects test-suite design, not runtime pass/fail."
-- "Partial: backend suite run ({N/M, X%}); frontend suite skipped (deps not installed / user declined)." }
+- "Partial: backend suite run ({N/M, X%}); frontend suite skipped (deps not installed / user declined)."
+- "Not assessable without setup — environment is `cold`; no test runner has its deps installed." }
 
 **Grade rubric.** A = best-practice everywhere. B = solid with small known gaps. C = works but has real rough edges. D = risky, don't ship. F = broken or absent. `+` / `−` denote half-steps; a dimension drops one tier for each missing obvious element (no backups, no deps automation, etc.). See the §2 Executive Summary table for the per-dimension grades.
 
@@ -60,7 +71,7 @@ Save the filled-in report to `reports/{project-name}_quality_assessment_{YYYY-MM
 | Dependency manifests | {list, e.g., "pyproject.toml, package.json"} | — |
 | Lockfiles present | {Yes/Partial/No} | {e.g., "uv.lock + package-lock.json, both committed"} |
 
-If any row is `Not measured` or approximate, say why in the Notes column. Do not silently omit.
+If any row is not `Measured`, tag it explicitly with one of the three assessability tiers from the Method & Limitations block — `Measured`, `Inferred from artifacts`, or `Not assessable without setup` — and explain why in the Notes column. Do not silently omit. Rows that could not be reached because of a `cold` environment tier should read `Not assessable without setup (environment tier: cold)` so the reader immediately understands what a different environment would change.
 
 ---
 
@@ -222,7 +233,7 @@ If no frontend exists: `— N/A: backend-only service`.
 A consolidated, machine-readable view of every finding a reviewer would track. Rows are drawn from §4 subsections; this table exists so a reader can triage without reading the full narrative. High/Critical rows must reappear in §6 Substantial Problems; Medium/Low roll into §8 Recommended Actions.
 
 **Severity**: Critical = production-blocking or data-loss risk; High = likely to cause incidents within 3 months; Medium = real risk but bounded; Low = minor quality/hygiene.
-**Confidence** (from Method & Limitations block): Verified / Likely / Inferred.
+**Confidence** (from Method & Limitations block): Verified / Likely / Inferred. A finding whose source §1 row is `Not assessable without setup` must not exceed **Inferred** — if the audit couldn't measure it, downstream claims are at best inferential.
 **Effort**: ≤1h / half-day / 1d / >1d.
 
 | ID | Dimension | Finding | Severity | Confidence | Evidence | Effort |
@@ -284,7 +295,7 @@ N+1. ...
 ## Notes for the skill-runner
 
 - The **Author row** must include the plugin version. Read `${CLAUDE_PLUGIN_ROOT}/.claude-plugin/plugin.json`, pull the `version` field, and substitute into the Author cell as `Claude (Opus 4.7) via the \`codebase-audit:report\` skill (vX.Y.Z)`. This makes every saved report self-identifying.
-- The **Method & Limitations block** (between Context and §1) is mandatory. Fill the "Dynamic validation" bullet based on whether Step 2b ran: if tests were run, state pass/fail + coverage; if not, state "No tests were run."
+- The **Method & Limitations block** (between Context and §1) is mandatory. Fill the "Dynamic validation" bullet based on whether Step 2b ran: if tests were run, state pass/fail + coverage; if not, state "No tests were run." Also fill the "Environment tier" line by copying the `ENVIRONMENT_TIER` and `TIER_REASON` emitted by `collect_stats.sh` — every report must carry this so the reader can tell whether an empty row is a gap in the project or a gap in the environment that ran the audit.
 - The **Summary Stats** table (§1) is mandatory. "Test suite run" and "Test coverage" rows default to `Not executed` / `Not measured`; only populate with numbers when Step 2b ran successfully.
 - The **Disaster Recovery & Backups subsection** (§3) is mandatory. If you cannot find evidence of a backup strategy, say so explicitly — do not omit the subsection.
 - The **dimension grade table** (§2) must include all 17 dimensions, including the newer ones (12-17). Use `— N/A` with a reason for rows that don't apply to this project type.

--- a/plugins/codebase-audit/skills/report/scripts/collect_stats.sh
+++ b/plugins/codebase-audit/skills/report/scripts/collect_stats.sh
@@ -5,7 +5,10 @@
 #   collect_stats.sh <repo-path>
 #
 # Produces human-readable output to stdout and writes the same to
-# /tmp/quality-assessment-stats.txt for the caller to reference.
+# ${TMPDIR:-/tmp}/quality-assessment-stats.txt for the caller to reference.
+#
+# Requires bash 4+. macOS ships with bash 3.2 as /bin/bash; the script
+# aborts loudly with an install hint if run under anything older.
 #
 # Sections:
 #   - Repo identity (name, branch, commit, remote)
@@ -14,14 +17,27 @@
 #   - Git activity (commits, contributors) for last 90 days
 #   - Dependency manifests + lockfile presence
 #   - Coverage artifact search
+#   - Test runner detection + test-command hints (for Step 2b orchestration)
 #   - CI workflow discovery + recent run timing (if gh is available)
 #   - Docker / deploy artifacts
 #   - Backup / restore evidence (grep only — does not assume tools)
+#   - Environment tier verdict (warm / partial / cold) — tells the skill
+#     whether dynamic validation (test execution) is viable and, if so,
+#     whether to consolidate missing-deps questions into one prompt
 #
 # The script is read-only on the target repo. It does not run tests
 # or install anything without asking.
 
 set -uo pipefail
+
+# Require bash 4+ (arrays with += append, `read -d ''`, nullglob used below).
+# macOS ships with bash 3.2 as /bin/bash; `brew install bash` provides a newer one.
+if ((${BASH_VERSINFO[0]:-0} < 4)); then
+  echo "error: collect_stats.sh requires bash 4+ (detected ${BASH_VERSION:-unknown})." >&2
+  echo "       On macOS, install with 'brew install bash' and re-run using" >&2
+  echo "       /opt/homebrew/bin/bash (Apple Silicon) or /usr/local/bin/bash (Intel)." >&2
+  exit 2
+fi
 
 REPO="${1:-}"
 if [[ -z "${REPO}" ]]; then
@@ -36,8 +52,14 @@ if [[ ! -d "${REPO}/.git" ]]; then
   echo "warning: '${REPO}' does not contain a .git directory — some stats will be missing" >&2
 fi
 
-OUT=/tmp/quality-assessment-stats.txt
+OUT="${TMPDIR:-/tmp}/quality-assessment-stats.txt"
 : > "${OUT}"
+
+# Tier-tracking flags. See the "Environment tier" section at the end of the script
+# for the final verdict. Signals are set as the respective sections run.
+HAS_LOC_TOOL=0
+TEST_RUNNER_DETECTED=0
+TEST_DEPS_INSTALLED=0
 
 log() {
   echo "$*" | tee -a "${OUT}"
@@ -71,6 +93,7 @@ elif command -v scc >/dev/null 2>&1; then
 elif command -v cloc >/dev/null 2>&1; then
   LOC_TOOL="cloc"
 fi
+[[ -n "${LOC_TOOL}" ]] && HAS_LOC_TOOL=1
 
 if [[ -z "${LOC_TOOL}" ]]; then
   log "tokei/scc/cloc not found on PATH."
@@ -138,7 +161,10 @@ else
   printf '%s\n' "${TEST_DIRS[@]}" | sort -u | tee -a "${OUT}"
   log ""
   log "Test LOC by directory (counting .py .ts .tsx .js .jsx .go .rs .java .rb .php .cs files):"
-  for d in $(printf '%s\n' "${TEST_DIRS[@]}" | sort -u); do
+  # `while read` instead of `for d in $(...)` so test-dir paths containing
+  # spaces don't get word-split across iterations.
+  while IFS= read -r d; do
+    [[ -z "${d}" ]] && continue
     full="${REPO}/${d}"
     [[ ! -d "${full}" ]] && continue
     loc=$(find "${full}" -type f \( \
@@ -152,7 +178,7 @@ else
       -o -name '*.rb' -o -name '*.php' -o -name '*.cs' \
       \) -not -path '*/node_modules/*' -not -path '*/.venv/*' | wc -l)
     printf '  %-50s %4d files / %6d LOC\n' "${d}" "${files}" "${loc}" | tee -a "${OUT}"
-  done
+  done < <(printf '%s\n' "${TEST_DIRS[@]}" | sort -u)
 fi
 
 # ----- Git activity -----
@@ -243,8 +269,10 @@ done
 if [[ -n "${PHPUNIT_CONFIG}" ]]; then
   if [[ -x "${REPO}/vendor/bin/phpunit" ]]; then
     log "  php: ${PHPUNIT_CONFIG} + vendor/bin/phpunit present (deps installed)"
+    TEST_DEPS_INSTALLED=1
   elif [[ -x "${REPO}/vendor/bin/pest" ]]; then
     log "  php: ${PHPUNIT_CONFIG} + vendor/bin/pest present (deps installed)"
+    TEST_DEPS_INSTALLED=1
   else
     log "  php: ${PHPUNIT_CONFIG} present, but vendor/ missing — deps not installed (skip Step 2b)"
   fi
@@ -259,6 +287,7 @@ if [[ -f "${REPO}/pytest.ini" || -f "${REPO}/tox.ini" ]] || grep -q '\[tool\.pyt
   [[ -z "${PYTEST_BIN}" ]] && command -v pytest >/dev/null 2>&1 && PYTEST_BIN="$(command -v pytest)"
   if [[ -n "${PYTEST_BIN}" ]]; then
     log "  python: pytest config + runner at ${PYTEST_BIN} (deps likely installed)"
+    TEST_DEPS_INSTALLED=1
   else
     log "  python: pytest config present, but pytest binary not found in .venv/venv/PATH (skip Step 2b)"
   fi
@@ -271,6 +300,7 @@ if [[ -f "${REPO}/package.json" ]]; then
   if [[ -n "${TEST_SCRIPT}" ]]; then
     if [[ -d "${REPO}/node_modules" ]]; then
       log "  js/ts: package.json ${TEST_SCRIPT} + node_modules/ present (deps installed)"
+      TEST_DEPS_INSTALLED=1
     else
       log "  js/ts: package.json ${TEST_SCRIPT} present, but node_modules/ missing (skip Step 2b)"
     fi
@@ -284,6 +314,7 @@ if [[ -f "${REPO}/go.mod" ]]; then
   if [[ "${GO_TEST_COUNT}" -gt 0 ]]; then
     log "  go: go.mod + ${GO_TEST_COUNT}+ *_test.go files (go test always works, deps auto-resolved)"
     TEST_RUNNER_FOUND=1
+    command -v go >/dev/null 2>&1 && TEST_DEPS_INSTALLED=1
   fi
 fi
 
@@ -292,6 +323,7 @@ if [[ -f "${REPO}/Cargo.toml" ]]; then
   if [[ -d "${REPO}/tests" ]] || grep -rq '#\[cfg(test)\]' "${REPO}/src" 2>/dev/null; then
     log "  rust: Cargo.toml + test modules present (cargo test handles deps)"
     TEST_RUNNER_FOUND=1
+    command -v cargo >/dev/null 2>&1 && TEST_DEPS_INSTALLED=1
   fi
 fi
 
@@ -300,6 +332,7 @@ if [[ -f "${REPO}/Gemfile" ]]; then
   if [[ -d "${REPO}/spec" || -d "${REPO}/test" ]]; then
     if [[ -f "${REPO}/Gemfile.lock" ]]; then
       log "  ruby: Gemfile + $(ls -d "${REPO}"/spec "${REPO}"/test 2>/dev/null | tr '\n' ' ')present (deps likely installed)"
+      TEST_DEPS_INSTALLED=1
     else
       log "  ruby: Gemfile + spec/test dir present, but no Gemfile.lock — run bundle install first"
     fi
@@ -312,9 +345,11 @@ if [[ -d "${REPO}/src/test/java" ]]; then
   if [[ -f "${REPO}/pom.xml" ]]; then
     log "  java: pom.xml + src/test/java/ present (mvn test — requires Maven on PATH)"
     TEST_RUNNER_FOUND=1
+    command -v mvn >/dev/null 2>&1 && TEST_DEPS_INSTALLED=1
   elif [[ -f "${REPO}/build.gradle" || -f "${REPO}/build.gradle.kts" ]]; then
     log "  java: build.gradle + src/test/java/ present (gradle test — requires Gradle on PATH)"
     TEST_RUNNER_FOUND=1
+    { command -v gradle >/dev/null 2>&1 || [[ -x "${REPO}/gradlew" ]]; } && TEST_DEPS_INSTALLED=1
   fi
 fi
 
@@ -337,6 +372,7 @@ while IFS= read -r pkg; do
     dir="$(dirname "${rel}")"
     if [[ -d "${REPO}/${dir}/node_modules" ]]; then
       log "  js/ts: ${rel} ${TEST_SCRIPT} + ${dir}/node_modules/ present (deps installed)"
+      TEST_DEPS_INSTALLED=1
     else
       log "  js/ts: ${rel} ${TEST_SCRIPT} present, but ${dir}/node_modules/ missing"
     fi
@@ -354,6 +390,7 @@ while IFS= read -r cfg; do
   dir="$(dirname "${rel}")"
   if [[ -d "${REPO}/${dir}/vendor" ]]; then
     log "  php: ${rel} + ${dir}/vendor/ present (deps installed)"
+    TEST_DEPS_INSTALLED=1
   else
     log "  php: ${rel} present (vendor status unknown)"
   fi
@@ -451,7 +488,20 @@ if command -v gh >/dev/null 2>&1 && [[ -d "${REPO}/.git" ]]; then
   if gh auth status >/dev/null 2>&1; then
     log ""
     log "Recent GitHub Actions runs (last 5, any workflow, main branch):"
-    (cd "${REPO}" && gh run list --branch main --limit 5 --json workflowName,status,conclusion,createdAt,updatedAt 2>/dev/null) | tee -a "${OUT}" || log "  (gh run list failed — not a GitHub repo or no auth)"
+    # Route through a temp file so we can inspect gh's exit code — piping to tee
+    # would mask gh failure behind tee's success and silently produce an empty
+    # result that reads as "no runs" rather than "gh couldn't ask".
+    GH_TMP="$(mktemp)"
+    if (cd "${REPO}" && gh run list --branch main --limit 5 --json workflowName,status,conclusion,createdAt,updatedAt >"${GH_TMP}" 2>/dev/null); then
+      if [[ -s "${GH_TMP}" ]]; then
+        tee -a "${OUT}" < "${GH_TMP}"
+      else
+        log "  (gh returned no runs for main — repo may have no CI history on this branch)"
+      fi
+    else
+      log "  (gh run list failed — not a GitHub repo, no auth, or network down)"
+    fi
+    rm -f "${GH_TMP}"
   else
     log "gh CLI present but not authenticated — skipping run-timing probe"
   fi
@@ -473,12 +523,18 @@ fi
 
 log ""
 log "Grep for backup/restore/dump evidence (excluding vendor/IDE/skill dirs):"
-BACKUP_HITS=$(grep -rlIiE 'pg_dump|mysqldump|mongodump|wal_?archive|restic|borg|rclone|s3 sync|storage[-_ ]box' \
-  --exclude-dir=.git --exclude-dir=node_modules --exclude-dir=.venv \
-  --exclude-dir=dist --exclude-dir=build --exclude-dir=htmlcov \
-  --exclude-dir=.claude --exclude-dir=.idea --exclude-dir=.vscode \
-  --exclude-dir=.planning --exclude-dir=reports \
-  "${REPO}" 2>/dev/null | head -20)
+# `find ... -prune` + `xargs grep` instead of `grep -rlI --exclude-dir=...`
+# because the `-r` recursive mode and `--exclude-dir` flag aren't portable
+# across GNU grep, BSD grep (macOS), and busybox grep. The find+xargs form
+# works everywhere POSIX-ish.
+BACKUP_HITS=$(find "${REPO}" \
+    \( -path '*/.git' -o -path '*/node_modules' -o -path '*/.venv' \
+       -o -path '*/dist' -o -path '*/build' -o -path '*/htmlcov' \
+       -o -path '*/.claude' -o -path '*/.idea' -o -path '*/.vscode' \
+       -o -path '*/.planning' -o -path '*/reports' \) -prune \
+    -o -type f -print0 2>/dev/null \
+  | xargs -0 grep -lEi 'pg_dump|mysqldump|mongodump|wal_?archive|restic|borg|rclone|s3 sync|storage[-_ ]box' 2>/dev/null \
+  | head -20)
 if [[ -n "${BACKUP_HITS}" ]]; then
   echo "${BACKUP_HITS}" | tee -a "${OUT}"
 else
@@ -512,6 +568,45 @@ shopt -u nullglob
 if [[ "${IDE_HIT}" = "0" ]]; then
   log "  (no IDE-committed inspection profile / editor config found — team relies on per-contributor editor defaults)"
 fi
+
+# ----- Environment tier -----
+# Classify what this environment can actually measure, so the skill can pick
+# the right Step 2b branch: warm (run tests straight away), partial (ask once
+# whether to install missing deps), or cold (skip dynamic validation, report
+# dynamic rows as "Not assessable without setup").
+section "Environment tier"
+
+if [[ "${TEST_RUNNER_FOUND}" = "1" ]] || [[ "${MONO_HITS}" -gt 0 ]]; then
+  TEST_RUNNER_DETECTED=1
+fi
+
+if [[ "${HAS_LOC_TOOL}" = "1" ]] && [[ "${TEST_DEPS_INSTALLED}" = "1" ]]; then
+  TIER="warm"
+  TIER_REASON="LOC tool on PATH and at least one test runner has its deps installed."
+elif [[ "${HAS_LOC_TOOL}" = "1" ]] || [[ "${TEST_RUNNER_DETECTED}" = "1" ]]; then
+  TIER="partial"
+  MISSING=()
+  [[ "${HAS_LOC_TOOL}" = "0" ]] && MISSING+=("no LOC tool (tokei/scc/cloc)")
+  [[ "${TEST_RUNNER_DETECTED}" = "1" ]] && [[ "${TEST_DEPS_INSTALLED}" = "0" ]] \
+    && MISSING+=("test runners detected but deps not installed")
+  [[ "${TEST_RUNNER_DETECTED}" = "0" ]] && MISSING+=("no test runner configs detected")
+  TIER_REASON="partial — $(IFS='; '; printf '%s' "${MISSING[*]}")."
+else
+  TIER="cold"
+  TIER_REASON="no LOC tool on PATH and no test runner with installed deps."
+fi
+
+# Grep-able one-liner per signal. SKILL.md reads these to pick the Step 2b branch.
+log "ENVIRONMENT_TIER: ${TIER}"
+log "TIER_REASON: ${TIER_REASON}"
+log "SIGNAL_LOC_TOOL: $([[ "${HAS_LOC_TOOL}" = "1" ]] && echo yes || echo no)"
+log "SIGNAL_TEST_RUNNER_DETECTED: $([[ "${TEST_RUNNER_DETECTED}" = "1" ]] && echo yes || echo no)"
+log "SIGNAL_TEST_DEPS_INSTALLED: $([[ "${TEST_DEPS_INSTALLED}" = "1" ]] && echo yes || echo no)"
+log ""
+log "Tier meaning for the report skill:"
+log "  warm    — test execution is viable; offer it per-suite."
+log "  partial — one consolidated install-or-skip question before per-suite offers."
+log "  cold    — skip dynamic validation; mark Step-2b rows 'Not assessable without setup'."
 
 # ----- Done -----
 section "Done"


### PR DESCRIPTION
## Summary

Teaches the `codebase-audit:report` skill to work honestly across the full environment spectrum — from a warm active-dev machine (Docker up, deps installed, test DB seeded) to a cold foreign clone (no tooling, no deps, every command would fail) — and hardens the underlying `collect_stats.sh` probe against the portability + error-masking issues that made cold-case audits silently degrade.

Three-part feature addition:

1. **Environment-tier verdict from `collect_stats.sh`** — the script emits grep-able `ENVIRONMENT_TIER: warm|partial|cold` plus per-signal `SIGNAL_*` flags so the skill can branch without regex-parsing.
2. **Single install-or-skip decision in SKILL.md** (new Step 2b.1a) — on `partial`, the skill asks the user *once* whether to install missing deps, run what's already runnable, or skip Step 2b entirely. No more N per-suite permission prompts. Install commands are quoted from the repo's own docs (README, Makefile, `package.json`) — never guessed.
3. **Section-level assessability vocabulary in the report template** — distinct from the existing claim-level confidence (Verified / Likely / Inferred), `§1 Summary Stats` rows now carry one of three section-level tiers: `Measured`, `Inferred from artifacts`, `Not assessable without setup`. Cold-clone reports state explicitly what tooling would be needed to upgrade each row.

Plus script hardening:

- bash 4+ version guard (loud failure with macOS `brew install bash` hint instead of cryptic syntax error)
- `\$TMPDIR` for output path (sandboxed environments)
- BSD-portable `find -prune … | xargs -0 grep -lEi` replacing `grep -rlI --exclude-dir=…` for backup-evidence search
- `while IFS= read` replacing `for d in \$(…)` so test-dir paths with spaces are counted
- `gh run list` routed through a temp file with explicit exit-code inspection instead of `tee`-masked pipeline

Minor-version bump (0.3.0 → 0.4.0). Additive only — existing reports still render.

## Test plan

- [x] `bash -n plugins/codebase-audit/skills/report/scripts/collect_stats.sh` parses clean after all edits
- [x] Running `collect_stats.sh` on this repo emits `ENVIRONMENT_TIER: partial` with `TIER_REASON: partial — no test runner configs detected.` and per-signal flags (`SIGNAL_LOC_TOOL: yes`, `SIGNAL_TEST_RUNNER_DETECTED: no`, `SIGNAL_TEST_DEPS_INSTALLED: no`)
- [x] `plugin.json` is valid JSON and reports version 0.4.0
- [ ] Manual: run the skill on a throwaway repo after merge; confirm Method & Limitations block shows the Environment tier row and §1 Notes use the new vocabulary
- [ ] Manual: induce a `cold` environment (minimal container, no tokei / no node / no composer) — confirm the script emits `cold` and the skill skips Step 2b with clear Not-assessable markers
- [ ] Manual: induce a `partial` environment (clone Node.js repo, delete `node_modules/`) — confirm the skill asks a single install-or-skip question, not per suite
- [ ] Post-merge release checklist per CLAUDE.md: tag `codebase-audit-v0.4.0`, publish GitHub release, confirm `/plugin marketplace update aimfeld` picks up the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)