### PR TITLE
Release codebase-audit v0.4.1 — bash 3.2 compatibility fix

### DIFF
--- a/.github/workflows/codebase-audit-script.yml
+++ b/.github/workflows/codebase-audit-script.yml
@@ -1,0 +1,37 @@
+name: codebase-audit collect_stats.sh smoke test
+
+# macOS runners ship stock /bin/bash 3.2.57 — the exact shell that motivated
+# issue #9. Invoking the script under /bin/bash here guards against anyone
+# accidentally reintroducing a bash-4-only construct.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'plugins/codebase-audit/skills/report/scripts/collect_stats.sh'
+      - '.github/workflows/codebase-audit-script.yml'
+  pull_request:
+    paths:
+      - 'plugins/codebase-audit/skills/report/scripts/collect_stats.sh'
+      - '.github/workflows/codebase-audit-script.yml'
+
+jobs:
+  smoke-test:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Show bash version
+        run: /bin/bash --version
+
+      - name: Run collect_stats.sh under stock /bin/bash
+        run: /bin/bash plugins/codebase-audit/skills/report/scripts/collect_stats.sh "$GITHUB_WORKSPACE"
+
+      - name: Assert output file exists and contains expected sections
+        run: |
+          OUT="${TMPDIR:-/tmp}/quality-assessment-stats.txt"
+          test -s "$OUT" || { echo "output file missing or empty: $OUT" >&2; exit 1; }
+          for header in "=== Identity ===" "=== LOC breakdown ===" "=== Git activity" "=== Environment tier ===" "ENVIRONMENT_TIER:"; do
+            grep -qF "$header" "$OUT" || { echo "missing expected marker: $header" >&2; exit 1; }
+          done
+          echo "All expected markers present."

--- a/.github/workflows/codebase-audit-script.yml
+++ b/.github/workflows/codebase-audit-script.yml
@@ -1,8 +1,10 @@
-name: codebase-audit collect_stats.sh smoke test
+name: codebase-audit stats
 
 # macOS runners ship stock /bin/bash 3.2.57 — the exact shell that motivated
 # issue #9. Invoking the script under /bin/bash here guards against anyone
-# accidentally reintroducing a bash-4-only construct.
+# accidentally reintroducing a bash-4-only construct. The weekly cron keeps
+# the README badge fresh and catches runner-image regressions (gh CLI
+# changes, toolchain updates) even when the script itself hasn't changed.
 
 on:
   push:
@@ -14,6 +16,9 @@ on:
     paths:
       - 'plugins/codebase-audit/skills/report/scripts/collect_stats.sh'
       - '.github/workflows/codebase-audit-script.yml'
+  schedule:
+    - cron: '0 6 * * 1'  # Mondays 06:00 UTC
+  workflow_dispatch:
 
 jobs:
   smoke-test:

--- a/plugins/codebase-audit/.claude-plugin/plugin.json
+++ b/plugins/codebase-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codebase-audit",
   "description": "Produces a thorough software quality assessment report for a git repository — architecture, security, database design, observability, testing, DR, GDPR, dependencies, frontend bundle, and CI/CD speed. Evidence-based grading with file:line citations.",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "author": {
     "name": "Adrian Imfeld",
     "email": "aimfeld80@gmail.com"

--- a/plugins/codebase-audit/CHANGELOG.md
+++ b/plugins/codebase-audit/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to the `codebase-audit` plugin are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [Semantic Versioning](https://semver.org/).
 
+## [0.4.1] — 2026-04-20
+
+### Fixed
+- **`collect_stats.sh` runs under stock macOS `/bin/bash` (3.2.57).** Dropped the bash 4+ version guard added in 0.4.0 — the script only uses features present in bash 3.2 (`+=` array append landed in 3.1, `read -d ''` in 2.05b, `nullglob` in 2.02), so the guard was fencing off a shell that actually works. Users who hadn't `brew install bash`'d were hitting a hard `exit 2` on the first step of `/codebase-audit:report`. Closes [#9](https://github.com/aimfeld/claude-plugins/issues/9). ([#10](https://github.com/aimfeld/claude-plugins/pull/10))
+
+### Added
+- **GitHub Actions smoke test for `collect_stats.sh`.** New `macos-latest` workflow (`.github/workflows/codebase-audit-script.yml`) runs the script under stock `/bin/bash 3.2.57` on every push/PR that touches the script, asserting exit 0 and that the expected section headers appear in the stats file. Locks in bash-3.2 compatibility so a future edit can't silently regress it. First CI workflow in this repo. ([#10](https://github.com/aimfeld/claude-plugins/pull/10))
+
 ## [0.4.0] — 2026-04-18
 
 ### Added
@@ -53,6 +61,7 @@ All notable changes to the `codebase-audit` plugin are documented here. Format f
 ### Added
 - Initial release: 16-dimension quality assessment skill with evidence-based grading and `file:line` citations.
 
+[0.4.1]: https://github.com/aimfeld/claude-plugins/releases/tag/codebase-audit-v0.4.1
 [0.4.0]: https://github.com/aimfeld/claude-plugins/releases/tag/codebase-audit-v0.4.0
 [0.3.0]: https://github.com/aimfeld/claude-plugins/releases/tag/codebase-audit-v0.3.0
 [0.2.1]: https://github.com/aimfeld/claude-plugins/releases/tag/codebase-audit-v0.2.1

--- a/plugins/codebase-audit/README.md
+++ b/plugins/codebase-audit/README.md
@@ -1,5 +1,7 @@
 # codebase-audit
 
+[![stats script CI](https://github.com/aimfeld/claude-plugins/actions/workflows/codebase-audit-script.yml/badge.svg?branch=main)](https://github.com/aimfeld/claude-plugins/actions/workflows/codebase-audit-script.yml)
+
 A [Claude Code](https://www.claude.com/product/claude-code) plugin that produces a thorough, evidence-based software quality assessment for any git repository — architecture, security, database design, observability, testing, disaster recovery, GDPR, dependency management, frontend bundle performance, and CI/CD speed.
 
 Every grade and finding is backed by a concrete `file:line` pointer so a reviewer can verify any claim in under a minute.

--- a/plugins/codebase-audit/skills/report/scripts/collect_stats.sh
+++ b/plugins/codebase-audit/skills/report/scripts/collect_stats.sh
@@ -7,8 +7,7 @@
 # Produces human-readable output to stdout and writes the same to
 # ${TMPDIR:-/tmp}/quality-assessment-stats.txt for the caller to reference.
 #
-# Requires bash 4+. macOS ships with bash 3.2 as /bin/bash; the script
-# aborts loudly with an install hint if run under anything older.
+# Runs under bash 3.2+ so stock macOS /bin/bash works without Homebrew bash.
 #
 # Sections:
 #   - Repo identity (name, branch, commit, remote)
@@ -29,15 +28,6 @@
 # or install anything without asking.
 
 set -uo pipefail
-
-# Require bash 4+ (arrays with += append, `read -d ''`, nullglob used below).
-# macOS ships with bash 3.2 as /bin/bash; `brew install bash` provides a newer one.
-if ((${BASH_VERSINFO[0]:-0} < 4)); then
-  echo "error: collect_stats.sh requires bash 4+ (detected ${BASH_VERSION:-unknown})." >&2
-  echo "       On macOS, install with 'brew install bash' and re-run using" >&2
-  echo "       /opt/homebrew/bin/bash (Apple Silicon) or /usr/local/bin/bash (Intel)." >&2
-  exit 2
-fi
 
 REPO="${1:-}"
 if [[ -z "${REPO}" ]]; then


### PR DESCRIPTION
## Summary

- Drops the bash 4+ version guard in `collect_stats.sh` so stock macOS `/bin/bash` (3.2.57) runs the script without `brew install bash`. The features the guard cited (`+=` array append, `read -d ''`, `nullglob`) all pre-date bash 3.2, so the guard was fencing off a shell that actually works. Users hitting `exit 2` on the first step of `/codebase-audit:report` (see #9) now pass straight through.
- Adds a `macos-latest` GitHub Actions smoke test (`.github/workflows/codebase-audit-script.yml`) that re-runs the script under `/bin/bash` on every push/PR touching the script and asserts the expected section headers appear. First CI workflow in this repo.
- Patch-bumps `codebase-audit` to `0.4.1`, per the release playbook in `CLAUDE.md`. No change to output shape, invocation surface, or dimensions — strictly a regression fix.

Closes #9.

## Test plan

- [x] `/bin/bash collect_stats.sh <claude-plugins>` — exits 0, stats file populated, exercises the `cold` tier path.
- [x] `/bin/bash collect_stats.sh <python+vitest repo>` — exits 0, exercises the `partial` tier path, pytest + nested vitest detection, `gh run list` probe, IDE-profile probe, deploy/bin probe.
- [ ] New Actions workflow passes on this PR on `macos-latest`.
- [ ] Post-merge: `/plugin marketplace update aimfeld` reports `0.4.1`, `/codebase-audit:report` runs cleanly on a throwaway repo under stock macOS `/bin/bash` with no version-guard message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)