### PR TITLE
Release codebase-audit v0.5.0 — credential-file sweep + canonical probes

### DIFF
--- a/.github/workflows/codebase-audit-script.yml
+++ b/.github/workflows/codebase-audit-script.yml
@@ -36,7 +36,128 @@ jobs:
         run: |
           OUT="${TMPDIR:-/tmp}/quality-assessment-stats.txt"
           test -s "$OUT" || { echo "output file missing or empty: $OUT" >&2; exit 1; }
-          for header in "=== Identity ===" "=== LOC breakdown ===" "=== Git activity" "=== Environment tier ===" "ENVIRONMENT_TIER:"; do
+          for header in "=== Identity ===" "=== LOC breakdown ===" "=== Git activity" "=== Credential file sweep ===" "CREDENTIAL_FILES_HIGH_CONFIDENCE_COUNT:" "CREDENTIAL_FILES_REVIEW_COUNT:" "=== Environment tier ===" "ENVIRONMENT_TIER:"; do
             grep -qF "$header" "$OUT" || { echo "missing expected marker: $header" >&2; exit 1; }
           done
           echo "All expected markers present."
+
+      - name: Credential-sweep fixture — seeds sentinel secrets, asserts no leak
+        run: |
+          # This is the load-bearing security test. It seeds a throwaway git
+          # repo with credential-shaped files containing recognizable SENTINEL
+          # strings, runs collect_stats.sh against that repo, and asserts the
+          # sentinels NEVER appear in the script's stdout or in its persisted
+          # output file. The script classifies via silent grep -q, so secret
+          # bytes must not reach the LLM's context — this CI check is what
+          # catches any regression that breaks that guarantee.
+          set -e
+          FIXTURE=$(mktemp -d)
+          cd "$FIXTURE"
+          git init -q
+          git config user.email t@t.com
+          git config user.name t
+
+          mkdir -p .creds apps/foo/deploy tests/fixtures
+
+          cat > .creds/client_secret_ACME-TOKEN.json <<'JSON'
+          {
+            "installed": {
+              "client_id": "abc.apps.googleusercontent.com",
+              "client_secret": "TEST_SENTINEL_OAUTH_SECRET_AAAA_BBBB"
+            }
+          }
+          JSON
+          echo 'STRIPE_SECRET_KEY=sk_live_TEST_ENV_SENTINEL_CCCC_DDDD' > .env
+          echo '# placeholder' > .env.example
+
+          cat > id_rsa <<'KEY'
+          -----BEGIN OPENSSH PRIVATE KEY-----
+          TEST_SENTINEL_SSH_PRIVATE_KEY_EEEE_FFFF
+          -----END OPENSSH PRIVATE KEY-----
+          KEY
+
+          cat > apps/foo/deploy/server.pem <<'PEM'
+          -----BEGIN PRIVATE KEY-----
+          TEST_SENTINEL_PEM_PRIVATE_GGGG_HHHH
+          -----END PRIVATE KEY-----
+          PEM
+
+          cat > apps/foo/deploy/server.crt <<'CRT'
+          -----BEGIN CERTIFICATE-----
+          TEST_SENTINEL_CERT_PUBLIC_IIII_JJJJ
+          -----END CERTIFICATE-----
+          CRT
+
+          cat > credentials.json <<'GCP'
+          {
+            "type": "service_account",
+            "private_key": "TEST_SENTINEL_GCP_PRIVATE_KKKK_LLLL",
+            "client_email": "foo@bar.iam.gserviceaccount.com"
+          }
+          GCP
+
+          # Fixture-directory file — must be excluded entirely.
+          cat > tests/fixtures/test.key <<'FIX'
+          -----BEGIN PRIVATE KEY-----
+          TEST_SENTINEL_FIXTURE_KEY_MMMM_NNNN
+          -----END PRIVATE KEY-----
+          FIX
+          # Public half — must be excluded by suffix.
+          echo "ssh-ed25519 AAAA..." > id_rsa.pub
+
+          git add -A
+          git commit -q -m "seed"
+
+          STDOUT_FILE=$(mktemp)
+          /bin/bash "$GITHUB_WORKSPACE/plugins/codebase-audit/skills/report/scripts/collect_stats.sh" "$FIXTURE" > "$STDOUT_FILE" 2>&1
+
+          PERSIST="${TMPDIR:-/tmp}/quality-assessment-stats.txt"
+
+          fail=0
+          for sentinel in \
+              TEST_SENTINEL_OAUTH_SECRET \
+              TEST_ENV_SENTINEL \
+              TEST_SENTINEL_SSH_PRIVATE \
+              TEST_SENTINEL_PEM_PRIVATE \
+              TEST_SENTINEL_CERT_PUBLIC \
+              TEST_SENTINEL_GCP_PRIVATE \
+              TEST_SENTINEL_FIXTURE_KEY
+          do
+            if grep -q "$sentinel" "$STDOUT_FILE"; then
+              echo "FAIL: sentinel '$sentinel' leaked to stdout" >&2
+              fail=1
+            fi
+            if grep -q "$sentinel" "$PERSIST"; then
+              echo "FAIL: sentinel '$sentinel' leaked to persisted output" >&2
+              fail=1
+            fi
+          done
+
+          # Expected paths + labels must appear.
+          for expected in \
+              "CREDENTIAL_FILES_HIGH_CONFIDENCE_COUNT: 3" \
+              "CREDENTIAL_FILES_REVIEW_COUNT: 3" \
+              ".creds/client_secret_ACME-TOKEN.json	real-oauth-client-secret" \
+              ".env	env-file" \
+              "id_rsa	ssh-private-key" \
+              "apps/foo/deploy/server.pem	real-private-key" \
+              "apps/foo/deploy/server.crt	public-cert-ignore" \
+              "credentials.json	real-gcp-service-account"
+          do
+            if ! grep -qF "$expected" "$PERSIST"; then
+              echo "FAIL: expected marker '$expected' missing from output" >&2
+              fail=1
+            fi
+          done
+
+          # Fixture-directory and public-half files must NOT appear.
+          for excluded in "tests/fixtures/test.key" "id_rsa.pub"; do
+            if grep -qF "$excluded" "$PERSIST"; then
+              echo "FAIL: excluded path '$excluded' unexpectedly listed" >&2
+              fail=1
+            fi
+          done
+
+          rm -rf "$FIXTURE" "$STDOUT_FILE"
+          if [ "$fail" -ne 0 ]; then exit 1; fi
+          echo "Credential-sweep leak test PASSED — no sentinels leaked, all expected labels present."

--- a/plugins/codebase-audit/.claude-plugin/plugin.json
+++ b/plugins/codebase-audit/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "codebase-audit",
   "description": "Produces a thorough software quality assessment report for a git repository — architecture, security, database design, observability, testing, DR, GDPR, dependencies, frontend bundle, and CI/CD speed. Evidence-based grading with file:line citations.",
-  "version": "0.4.1",
+  "version": "0.5.0",
   "author": {
     "name": "Adrian Imfeld",
     "email": "aimfeld80@gmail.com"

--- a/plugins/codebase-audit/CHANGELOG.md
+++ b/plugins/codebase-audit/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to the `codebase-audit` plugin are documented here. Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versioning follows [Semantic Versioning](https://semver.org/).
 
+## [0.5.0] — 2026-04-21
+
+### Added
+- **Credential-file sweep in `collect_stats.sh`.** The script now scans `git ls-files` for credential-shaped filenames — `.env` (non-sample), SSH private keys, OAuth / GCP / AWS / Firebase credential JSONs, k8s configs, anything under `.creds/`/`.credentials/`/`.secrets/`/`.keys/`, TLS keystores — and emits two tiered blocks: `CREDENTIAL_FILES_HIGH_CONFIDENCE` for near-certain matches and `CREDENTIAL_FILES_REVIEW` for patterns with false-positive rate (`.pem`/`.key`/`.pfx`, generic `credentials*.json`). Closes the false-negative that let `.creds/client_secret_*.json` files slip through the previous content-only grep. Fixture-path exclusions (`tests/`, `__tests__/`, `fixtures/`, `vendor/`, `node_modules/`, `ca-certificates/`, etc.) keep test suites from lighting up the sweep.
+- **Non-leak-by-construction classification.** Every review-tier file is labeled via silent `grep -q` probes (PEM headers, JSON key-name presence) so file contents never reach stdout or the persisted stats file. Labels like `real-private-key`, `real-gcp-service-account`, `public-cert-ignore`, and `binary-keystore-not-inspected` let the skill grade without ever reading the body. Private keys, environment variable values, SSH secrets, and password bytes are guaranteed to stay out of the LLM's context. A new CI assertion seeds sentinel-bearing fixtures and fails the build if any sentinel appears in the script's output.
+- **Quarantine rule in `dimensions.md` Dim 4.** Any path surfaced by the credential sweep is **read-forbidden** for the remainder of the audit: no `Read`, `cat`, `head`, or context-emitting grep on those paths. The existing Dim 4 content greps (`git grep` for `API_KEY`, `ghp_`, `-----BEGIN`) now require `:(exclude)<path>` pathspecs for every `CREDENTIAL_FILES_*` entry so a committed `.env` cannot leak its values through a pattern match.
+- **Secrets grade floor.** Any `CREDENTIAL_FILES_HIGH_CONFIDENCE` hit, or any `CREDENTIAL_FILES_REVIEW` hit with a `real-*` or `binary-keystore-not-inspected` label, caps the Secrets dimension at **D** until the file is rotated, its git history is filtered, and its path is added to `.gitignore`. Directly closes the audit-inflation pattern that let Secrets climb to A− while an OAuth client secret was still committed.
+- **Canonical probes for counted metrics in `dimensions.md`.** Dims 3 (bare excepts), 5 (TODO/FIXME), 7 (raw-SQL injection / CORS wildcard / Sentry PII), 10 (Sentry coverage / correlation IDs), and 14 (over-pinned apps in monorepos) now ship exact `rg`/`find` commands to run verbatim, with fixed exclusion lists. Pins the methodology so two runs on the same code produce the same numbers, and closes the reliability gap where a 23% drift in bare-except counts was driven by grep-scope drift rather than real code change.
+
 ## [0.4.1] — 2026-04-20
 
 ### Fixed
@@ -61,6 +70,7 @@ All notable changes to the `codebase-audit` plugin are documented here. Format f
 ### Added
 - Initial release: 16-dimension quality assessment skill with evidence-based grading and `file:line` citations.
 
+[0.5.0]: https://github.com/aimfeld/claude-plugins/releases/tag/codebase-audit-v0.5.0
 [0.4.1]: https://github.com/aimfeld/claude-plugins/releases/tag/codebase-audit-v0.4.1
 [0.4.0]: https://github.com/aimfeld/claude-plugins/releases/tag/codebase-audit-v0.4.0
 [0.3.0]: https://github.com/aimfeld/claude-plugins/releases/tag/codebase-audit-v0.3.0

--- a/plugins/codebase-audit/skills/report/references/dimensions.md
+++ b/plugins/codebase-audit/skills/report/references/dimensions.md
@@ -53,9 +53,18 @@ Read only the sections for dimensions you're currently assessing. You do not nee
 
 **Question:** When something goes wrong, will the maintainer know, and will they have enough context to debug?
 
+**Canonical probes (run verbatim — different greps give different counts, which makes re-audits look like the code changed when it didn't):**
+
+- Python bare excepts (files): `rg -l '^\s*except\s*:\s*(#.*)?$' -t py --glob '!tests/**' --glob '!test/**' --glob '!__tests__/**' --glob '!fixtures/**' --glob '!reports/**' | wc -l`
+- Python bare excepts (total sites): `rg -c '^\s*except\s*:\s*(#.*)?$' -t py --glob '!tests/**' --glob '!test/**' --glob '!__tests__/**' --glob '!fixtures/**' --glob '!reports/**' | awk -F: '{s+=$NF} END {print s+0}'`
+- JS/TS empty catches (files): `rg -l 'catch\s*\([^)]*\)\s*\{\s*\}' -t ts -t tsx -t js -t jsx --glob '!node_modules/**' --glob '!tests/**' --glob '!__tests__/**' --glob '!reports/**' | wc -l`
+- Go error-dropping `_ =` (rough): `rg -c '_\s*=\s*[a-zA-Z_][a-zA-Z0-9_.]*\(' -t go --glob '!vendor/**' --glob '!*_test.go' | awk -F: '{s+=$NF} END {print s+0}'` — this is a *signal* for dropped error returns, read a sample to confirm.
+
+Report the exact numbers these commands produce; if you diverge from them (e.g., to include tests or use a different pattern), say so and say why.
+
 **Probes:**
+- Run the canonical probes above. Report counts.
 - Grep for `capture_exception`, `Sentry.captureException`, `logger.error`, `panic`, `rescue`. Count sites. Divide by total LOC for a rough density.
-- Grep for bare `except:` / `catch (e)` / `catch { }` — any found should be called out.
 - Check retry loops: do they capture on every attempt (noisy) or only the final failure (correct)?
 - Check whether error messages embed variable data (fragments Sentry grouping) vs use `set_context` / `set_tag`.
 - Frontend: global error handlers on `QueryCache`, `MutationCache`, `window.onerror`, `unhandledrejection`.
@@ -78,8 +87,23 @@ Read only the sections for dimensions you're currently assessing. You do not nee
 
 **Question:** Is there anything in the repo that should be rotated?
 
+### Quarantine rule (non-negotiable)
+
+Any path listed in `CREDENTIAL_FILES_HIGH_CONFIDENCE` or `CREDENTIAL_FILES_REVIEW` in the stats output is **read-forbidden** for the remainder of this audit. Do not call `Read`, `cat`, `head`, `tail`, or any tool that emits file contents on those paths. The bash-produced classification label is the only signal you use. The report cites the path, never the body. The purpose is simple: secret bytes must not enter the LLM context — once they're in context they can be logged, cached, or echoed back, and that risk is unacceptable for passwords, private keys, and env-var values.
+
+When running the content greps in Probe 1 below, **exclude every entry in `CREDENTIAL_FILES_HIGH_CONFIDENCE` and `CREDENTIAL_FILES_REVIEW`** via `:(exclude)<path>` pathspecs (for `git grep`) or `--exclude=<path>` (for `grep`/`rg`). Without these exclusions, a committed `.env` or credential JSON would match `API_KEY=` / `-----BEGIN` / `"client_secret"` and leak the *value* through the grep output. The quarantine is what prevents that.
+
 **Probes:**
-- `git grep` for common secret patterns: `API_KEY`, `SECRET_KEY`, `PASSWORD`, `TOKEN`, `AWS_`, `sk-`, `xoxb-`, `ghp_`, `-----BEGIN`, `postgres://`, `mysql://`. **Exclude `reports/`, `.planning/`, `docs/`, `.claude/`, and `.idea/`** from these greps — the report this skill writes lives in `reports/`, and prior reports will contain literal pattern strings that self-match on re-runs. Use `--exclude-dir=reports --exclude-dir=.planning --exclude-dir=docs --exclude-dir=.claude --exclude-dir=.idea` (or the `git grep` equivalent).
+
+- **Probe 0 — consult `CREDENTIAL_FILES_HIGH_CONFIDENCE` and `CREDENTIAL_FILES_REVIEW` from the stats output.** The bash script has already classified each file using silent content-free probes (`grep -q` on PEM headers and JSON key names). Treat the labels as authoritative:
+  - **HIGH_CONFIDENCE hits.** Real secret by default — the filename/directory convention is canonical. No content inspection needed, ever. Flag as Critical. Labels you'll see: `real-oauth-client-secret`, `real-gcp-service-account`, `ssh-private-key`, `kubeconfig`, `env-file`, `credential-dir-file`, `credential-file`.
+  - **REVIEW hits** with `real-*` label (`real-private-key`, `real-private-key-encrypted`, `real-gcp-service-account`, `real-oauth-client-secret`, `real-aws-credentials`, `real-htpasswd`) → real secret. Flag as Critical.
+  - **REVIEW hits** with `binary-keystore-not-inspected` label → treat as real secret by default (a committed `.pfx`/`.p12`/`.jks` outside a fixture path is almost always a real keystore).
+  - **REVIEW hits** with `public-cert-ignore` / `public-key-ignore` / `csr-public-ignore` → public material, not a grade-floor trigger. Mention only if the public material shouldn't be in the source tree (e.g., a production CA bundle that should ship in the container image).
+  - **REVIEW hits** with `unclassified` label → cite the path, flag for human review, **do not read the file**, do not grade-floor. The label means the bash probe couldn't identify the shape; a human should open it in a scratch buffer outside the audit.
+  - **Report format per hit:** cite the path. If the path itself contains a token-shaped component (e.g., `client_secret_<TOKEN>.json`), redact the token component as `<REDACTED-TOKEN>` in §4 prose; the full path stays in the §5 Evidence column so the maintainer can locate the file.
+
+- **Probe 1 — `git grep` for common secret patterns** in source code (credential files are already handled by Probe 0, and **must be excluded from this grep** per the Quarantine rule): `API_KEY`, `SECRET_KEY`, `PASSWORD`, `TOKEN`, `AWS_`, `sk-`, `xoxb-`, `ghp_`, `-----BEGIN`, `postgres://`, `mysql://`. **Also exclude `reports/`, `.planning/`, `docs/`, `.claude/`, and `.idea/`** — prior reports will contain literal pattern strings that self-match on re-runs. Use `--exclude-dir=reports --exclude-dir=.planning --exclude-dir=docs --exclude-dir=.claude --exclude-dir=.idea` plus a `:(exclude)<path>` pathspec for every `CREDENTIAL_FILES_*` entry (or the `grep`/`rg` equivalent).
 - Check `.env*` files are in `.gitignore` and not tracked (`git ls-files | grep -E '\.env'`).
 - Look for the config loader (e.g., Pydantic `BaseSettings`, `dotenv`, `viper`, `node-config`). Confirm defaults are placeholders (`change-me`, `localhost`) not real values.
 - Check `Dockerfile` for `ARG`-baked credentials, `ENV` with real values.
@@ -95,6 +119,10 @@ Read only the sections for dimensions you're currently assessing. You do not nee
 - `.env` committed.
 - Dockerfile bakes credentials at build time.
 
+**Grade floor (supersedes all positive signals in this dimension):**
+- **Any** `CREDENTIAL_FILES_HIGH_CONFIDENCE` hit, or any `CREDENTIAL_FILES_REVIEW` hit whose bash-emitted label starts with `real-` or is `binary-keystore-not-inspected` → Secrets dimension **cannot exceed D** until the file is rotated (treat it as compromised), the git history is filtered (`git filter-repo` or equivalent), and the path is added to `.gitignore`. This is a hard floor: even if every other probe in this dimension looks clean, a tracked credential file holds the grade at D. Cite the floor explicitly in the §4.4 finding.
+- Labels `public-cert-ignore`, `public-key-ignore`, `csr-public-ignore`, and `unclassified` are **not** grade-floor triggers.
+
 If you find anything that could be a real secret, redact it in the report (`<REDACTED: pattern match>`) and flag it as immediate-action.
 
 ---
@@ -103,8 +131,15 @@ If you find anything that could be a real secret, redact it in the report (`<RED
 
 **Question:** Is the codebase living in the present, or are there ghost rooms?
 
+**Canonical probes (run verbatim):**
+
+- TODO / FIXME / XXX / HACK / DEPRECATED (total sites): `rg -c '\b(TODO|FIXME|XXX|HACK|DEPRECATED)\b' --glob '!node_modules/**' --glob '!vendor/**' --glob '!.venv/**' --glob '!dist/**' --glob '!build/**' --glob '!reports/**' --glob '!CHANGELOG.md' --glob '!CLAUDE.md' | awk -F: '{s+=$NF} END {print s+0}'`
+- Same marker, file count: replace `-c` with `-l` and `awk` with `wc -l`.
+
+Report the exact numbers. Spot-check a handful (the oldest-looking, the scariest-sounding) — the count is the metric, the spot-check is the evidence.
+
 **Probes:**
-- Grep for `TODO`, `FIXME`, `XXX`, `HACK`, `DEPRECATED`. Count and spot-check.
+- Run the canonical probe above.
 - Look for commented-out code blocks (lines starting with `//` or `#` that are clearly code). A small script: count consecutive comment lines that contain `(`, `=`, `;`.
 - Check for magic numbers in decision logic: grep for comparisons to numeric literals that aren't 0/1 (`if (x > 42)`, `if x < 3600`). Each magic number should ideally be a named constant.
 - Dead imports / unused exports: if the language has a detector (knip, ts-unused-exports, vulture, unused in Rust), check CI for it.
@@ -158,9 +193,19 @@ If you find anything that could be a real secret, redact it in the report (`<RED
 
 **Question:** Would a reviewer with a security hat on flag anything?
 
+**Canonical probes (run verbatim — the SQL-injection count specifically drifted between prior audits):**
+
+- Python raw-SQL interpolation (f-strings into execute): `rg -n 'execute\s*\(\s*f["\x27]' -t py --glob '!tests/**' --glob '!test/**' --glob '!reports/**'`
+- Python raw-SQL concatenation into execute/query: `rg -n 'execute\s*\([^)]*\+|query\s*\([^)]*\+' -t py --glob '!tests/**' --glob '!test/**' --glob '!reports/**'`
+- JS/TS string-concat into query (Postgres/mysql drivers): `rg -n 'query\s*\(\s*[`\x27"][^`\x27"]*\$\{' -t ts -t tsx -t js --glob '!node_modules/**' --glob '!tests/**'`
+- CORS wildcard: `rg -n 'allow_origins\s*=\s*\[\s*["\x27]\*["\x27]|Access-Control-Allow-Origin["\x27:]\s*\*' --glob '!node_modules/**' --glob '!reports/**'`
+- Sentry PII flag (grep for `send_default_pii=True`): `rg -n 'send_default_pii\s*=\s*True' -t py --glob '!reports/**'`
+
+Report every hit line. Every raw-SQL hit is a §6 Substantial Problem candidate regardless of overall grade.
+
 **Probes:**
 - Auth dependencies: find the auth middleware / dependency. Grep for routes that should require auth but don't declare the dependency.
-- SQL: grep for f-string / concatenation into `execute()` / `query()` / `raw()`. Any finding is immediate-action.
+- SQL: run the canonical probes above. Any finding is immediate-action.
 - ORM usage: is every query going through the ORM or query builder?
 - CORS: check for `allow_origins=["*"]` or equivalent in production config.
 - CSRF / OAuth state: if OAuth is present, check the state-parameter handling. Is `secrets.token_urlsafe` / `crypto.randomUUID` used? Is the state validated on callback?
@@ -249,9 +294,18 @@ If no frontend, mark `— N/A`.
 
 **Question:** When the app is running in production at 3 AM, what can you see?
 
+**Canonical probes (run verbatim):**
+
+- Sentry capture sites: `rg -c 'capture_exception|Sentry\.captureException|sentry_sdk\.capture_' --glob '!node_modules/**' --glob '!reports/**' | awk -F: '{s+=$NF} END {print s+0}'`
+- Apps with Sentry init (monorepo heuristic): `rg -l 'sentry_sdk\.init\(|Sentry\.init\(' --glob '!node_modules/**' --glob '!reports/**' | wc -l`
+- Correlation-ID plumbing: `rg -c '(request_id|trace_id|correlation_id|X-Request-Id)' --glob '!node_modules/**' --glob '!reports/**' | awk -F: '{s+=$NF} END {print s+0}'`
+- JSON logger presence: `rg -l 'python-json-logger|pino|zap|zerolog|JsonFormatter' --glob '!node_modules/**' --glob '!reports/**'`
+
+Report both absolute counts and (where meaningful) coverage ratios — e.g., "Sentry init in 13 of 42 apps = 31%".
+
 **Probes:**
+- Run the canonical probes above.
 - Logging format: plain `logging.info()` vs JSON formatter (`python-json-logger`, `pino`, `zap`, `zerolog`). JSON is required for aggregation.
-- Request correlation: grep for `request_id` / `trace_id` / `correlation_id`. Present?
 - Metrics endpoint: `/metrics`, Prometheus client, OTEL exporter.
 - Slow-query logging: SQLAlchemy `before_cursor_execute` / `after_cursor_execute` hook, or ORM-level `before_query`.
 - Sentry `before_send` with fingerprinting.
@@ -358,6 +412,22 @@ If the app stores no PII at all (public data, no accounts), mark `— N/A: no us
 ## 14. Dependency management & supply chain
 
 **Question:** Are third-party deps kept patched, and is the supply chain hardened against bad packages?
+
+**Canonical probes (run verbatim):**
+
+- Python over-pinned apps in a monorepo (common footgun — each app re-pinning transitive deps decouples it from any central upgrade strategy). Flags sub-projects with >15 exact pins in `requirements.txt`, `requirements-*.txt`, or `[project] dependencies` arrays:
+  ```
+  find . -path '*/node_modules' -prune -o -path '*/.venv' -prune -o -path '*/vendor' -prune -o \
+    \( -name 'requirements*.txt' -o -name 'constraints*.txt' \) -print 2>/dev/null \
+    | while IFS= read -r f; do
+        c=$(grep -cE '^[A-Za-z0-9_.-]+[[:space:]]*==' "$f" 2>/dev/null); c=${c:-0}
+        [ "${c}" -gt 15 ] 2>/dev/null && printf '  %s: %d pinned\n' "$f" "$c"
+      done
+  ```
+  Equivalent for Node (`package.json` with >15 exact-version `^`-less / `~`-less deps), Ruby (`Gemfile` lines with `'= x.y.z'`), Go (`go.mod` exact version count isn't a red flag — Go's semver is different). For monorepos, finding 2+ such apps is a §6 Substantial Problem candidate.
+- Dockerfile base-image pinning: `rg -n '^FROM\s+' -g '**/Dockerfile*' --glob '!reports/**'` and note which lines use `@sha256:` (pinned) vs plain tag (floating).
+
+Report the exact list of over-pinned apps with their pin counts, not just "several apps are over-pinned."
 
 **Probes:**
 - **Automation:**

--- a/plugins/codebase-audit/skills/report/scripts/collect_stats.sh
+++ b/plugins/codebase-audit/skills/report/scripts/collect_stats.sh
@@ -559,6 +559,179 @@ if [[ "${IDE_HIT}" = "0" ]]; then
   log "  (no IDE-committed inspection profile / editor config found — team relies on per-contributor editor defaults)"
 fi
 
+# ----- Credential file sweep -----
+# Path-based scan for credential-like files in git-tracked paths. This exists
+# because the Dim 4 content greps (git grep for API_KEY=, ghp_, -----BEGIN, …)
+# miss credential JSON files whose bodies are valid JSON for an OAuth client
+# — "client_secret" is a JSON *key* there, not one of the regex anchors.
+#
+# SECURITY INVARIANT. Secret bytes must never enter the LLM's context. This
+# section classifies files using grep -q (silent, exit-code only) so matched
+# content is never echoed on stdout. The audit skill quarantines every listed
+# path and treats it as read-forbidden — it cites paths, never reads bodies.
+# See dimensions.md Dim 4 "Quarantine rule" for the enforcement contract.
+#
+# Two tiers:
+#   HIGH_CONFIDENCE — filename alone is canonical evidence (.env, SSH keys,
+#                     client_secret*.json, anything under .creds/ etc.).
+#                     Drives the Secrets grade floor.
+#   REVIEW         — *.pem / *.key / generic credentials*.json / keystores.
+#                     These collide with test fixtures, public certs, CA
+#                     bundles. Bash classifies each via first-line PEM header
+#                     or JSON key-name grep; labels let the skill decide
+#                     whether to grade-floor.
+section "Credential file sweep"
+
+if [[ -d "${REPO}/.git" ]]; then
+  # Fixture / vendor / third-party path fragments — exclude before matching.
+  # Generic across Python/TS/Go/Rust/Java/Ruby/PHP/C# layouts.
+  CRED_EXCLUDE_RE='(^|/)(tests?|__tests__|spec/fixtures|cypress/fixtures|fixtures|testdata|test_data|mocks|node_modules|vendor|third_party|ca-certificates)(/|$)'
+
+  # HIGH_CONFIDENCE patterns: directory conventions + canonical credential basenames.
+  HC_RE='(^|/)\.(creds|credentials|secrets|keys)/|(^|/)(client_secret[^/]*\.json|service[_-]account[^/]*\.json|serviceAccountKey\.json|firebase-adminsdk-[^/]*\.json|kubeconfig|[^/]+\.kubeconfig|id_rsa|id_ed25519|id_ecdsa|id_dsa|\.env(\.[^./]+)?)$'
+  # Exclude sample/placeholder .env variants and public-half suffixes.
+  HC_EXCLUDE_RE='\.env\.(example|sample|template|dist|default|local\.example)$|(^|/)\.env\.example$|\.pub$|\.pub\.(key|pem)$'
+
+  # REVIEW patterns: real false-positive rate — classify via bash content probe.
+  REVIEW_RE='\.(pem|key|crt|cer|pfx|p12|keystore|jks)$|(^|/)credentials[^/]*\.json$|(^|/)gcp-[^/]*\.json$|(^|/)\.htpasswd$'
+  REVIEW_EXCLUDE_RE='\.pub\.(key|pem|crt|cer)$|(^|/)[^/]+\.pub$'
+
+  # --- Silent classifiers ---
+  # These use `grep -q` so matched file content is NEVER echoed on stdout.
+  # Only the classification string ("real-private-key", "public-cert-ignore",
+  # etc.) reaches the caller. This is the load-bearing guarantee that the
+  # audit skill's LLM context cannot be polluted with secret bytes.
+  classify_pem() {
+    local f="$1"
+    if   grep -qE '^-----BEGIN ([A-Z]+ )?PRIVATE KEY-----' "$f" 2>/dev/null; then
+      printf 'real-private-key'
+    elif grep -qE '^-----BEGIN ENCRYPTED PRIVATE KEY-----' "$f" 2>/dev/null; then
+      printf 'real-private-key-encrypted'
+    elif grep -qE '^-----BEGIN OPENSSH PRIVATE KEY-----' "$f" 2>/dev/null; then
+      printf 'real-private-key'
+    elif grep -qE '^-----BEGIN CERTIFICATE-----' "$f" 2>/dev/null; then
+      printf 'public-cert-ignore'
+    elif grep -qE '^-----BEGIN PUBLIC KEY-----' "$f" 2>/dev/null; then
+      printf 'public-key-ignore'
+    elif grep -qE '^-----BEGIN CERTIFICATE REQUEST-----' "$f" 2>/dev/null; then
+      printf 'csr-public-ignore'
+    else
+      printf 'unclassified'
+    fi
+  }
+
+  classify_json_cred() {
+    local f="$1"
+    # Match only JSON KEY NAMES, never VALUES. grep -q is silent.
+    if   grep -qE '"private_key"[[:space:]]*:' "$f" 2>/dev/null \
+      && grep -qE '"client_email"[[:space:]]*:' "$f" 2>/dev/null; then
+      printf 'real-gcp-service-account'
+    elif grep -qE '"client_secret"[[:space:]]*:' "$f" 2>/dev/null; then
+      printf 'real-oauth-client-secret'
+    elif grep -qE '"aws_access_key_id"[[:space:]]*:' "$f" 2>/dev/null; then
+      printf 'real-aws-credentials'
+    else
+      printf 'unclassified'
+    fi
+  }
+
+  classify_review() {
+    local f="$1"
+    case "$f" in
+      *.pem|*.key|*.crt|*.cer) classify_pem "$f" ;;
+      *.pfx|*.p12|*.keystore|*.jks) printf 'binary-keystore-not-inspected' ;;
+      *.json) classify_json_cred "$f" ;;
+      *.htpasswd|*/\.htpasswd) printf 'real-htpasswd' ;;
+      *) printf 'unclassified' ;;
+    esac
+  }
+
+  # Label HIGH_CONFIDENCE entries purely by filename convention — no content read.
+  label_hc() {
+    local path="$1"
+    case "${path}" in
+      *client_secret*.json)                                         printf 'real-oauth-client-secret' ;;
+      *service_account*.json|*service-account*.json|*serviceAccountKey.json|*firebase-adminsdk-*.json)
+                                                                    printf 'real-gcp-service-account' ;;
+      id_rsa|id_ed25519|id_ecdsa|id_dsa|*/id_rsa|*/id_ed25519|*/id_ecdsa|*/id_dsa)
+                                                                    printf 'ssh-private-key' ;;
+      kubeconfig|*/kubeconfig|*.kubeconfig)                         printf 'kubeconfig' ;;
+      .creds/*|.credentials/*|.secrets/*|.keys/*|*/.creds/*|*/.credentials/*|*/.secrets/*|*/.keys/*)
+                                                                    printf 'credential-dir-file' ;;
+      .env|*/\.env)                                                 printf 'env-file' ;;
+      *.env|*/\.env.*)                                              printf 'env-file' ;;
+      *)                                                            printf 'credential-file' ;;
+    esac
+  }
+
+  # Collect matches. `|| true` keeps `set -e`/pipefail happy when grep returns
+  # no matches (exit 1, which pipefail propagates). We want an empty list, not
+  # a script abort.
+  HC_LIST=$(git -C "${REPO}" ls-files 2>/dev/null \
+    | grep -Ev "${CRED_EXCLUDE_RE}" \
+    | grep -E "${HC_RE}" \
+    | grep -Ev "${HC_EXCLUDE_RE}" \
+    || true)
+
+  REVIEW_LIST_RAW=$(git -C "${REPO}" ls-files 2>/dev/null \
+    | grep -Ev "${CRED_EXCLUDE_RE}" \
+    | grep -E "${REVIEW_RE}" \
+    | grep -Ev "${REVIEW_EXCLUDE_RE}" \
+    || true)
+
+  # Remove HC overlap from REVIEW (HIGH_CONFIDENCE wins). Only subtract when
+  # both lists are non-empty — `grep -Fxv -f <(echo "")` would incorrectly
+  # drop every line as "matches the empty string".
+  if [[ -n "${HC_LIST}" ]] && [[ -n "${REVIEW_LIST_RAW}" ]]; then
+    REVIEW_LIST=$(printf '%s\n' "${REVIEW_LIST_RAW}" \
+      | grep -Fxv -f <(printf '%s\n' "${HC_LIST}") \
+      || true)
+  else
+    REVIEW_LIST="${REVIEW_LIST_RAW}"
+  fi
+
+  # Counts — empty string => 0, else wc -l on a newline-terminated list.
+  if [[ -z "${HC_LIST}" ]]; then
+    HC_COUNT=0
+  else
+    HC_COUNT=$(printf '%s\n' "${HC_LIST}" | wc -l | tr -d ' ')
+  fi
+  if [[ -z "${REVIEW_LIST}" ]]; then
+    REVIEW_COUNT=0
+  else
+    REVIEW_COUNT=$(printf '%s\n' "${REVIEW_LIST}" | wc -l | tr -d ' ')
+  fi
+
+  log "CREDENTIAL_FILES_HIGH_CONFIDENCE_COUNT: ${HC_COUNT}"
+  if [[ "${HC_COUNT}" != "0" ]]; then
+    log "CREDENTIAL_FILES_HIGH_CONFIDENCE:"
+    while IFS= read -r cred_path; do
+      [[ -z "${cred_path}" ]] && continue
+      cred_label=$(label_hc "${cred_path}")
+      printf '  %s\t%s\n' "${cred_path}" "${cred_label}" | tee -a "${OUT}"
+    done <<<"${HC_LIST}"
+  fi
+
+  log "CREDENTIAL_FILES_REVIEW_COUNT: ${REVIEW_COUNT}"
+  if [[ "${REVIEW_COUNT}" != "0" ]]; then
+    log "CREDENTIAL_FILES_REVIEW:"
+    while IFS= read -r cred_path; do
+      [[ -z "${cred_path}" ]] && continue
+      cred_label=$(classify_review "${REPO}/${cred_path}")
+      printf '  %s\t%s\n' "${cred_path}" "${cred_label}" | tee -a "${OUT}"
+    done <<<"${REVIEW_LIST}"
+  fi
+
+  if [[ "${HC_COUNT}" = "0" ]] && [[ "${REVIEW_COUNT}" = "0" ]]; then
+    log "(No suspicious credential files matched — expected baseline.)"
+  else
+    log ""
+    log "Quarantine reminder: the audit skill MUST NOT Read() any path listed"
+    log "above. Classification above was produced by silent grep -q probes so no"
+    log "file content has reached stdout. See dimensions.md Dim 4 'Quarantine rule'."
+  fi
+fi
+
 # ----- Environment tier -----
 # Classify what this environment can actually measure, so the skill can pick
 # the right Step 2b branch: warm (run tests straight away), partial (ask once


### PR DESCRIPTION
## Summary

Two audits of the same monorepo a week apart (both on v0.4.1) produced materially different results — the newer report missed a committed OAuth client secret, dropped two over-pinned apps that had been flagged before, and reported bare-except counts that drifted 23% with no code change. Root causes were structural: the Dim 4 secrets probe only checked *content* via `git grep` for patterns like `API_KEY=` / `ghp_` / `-----BEGIN`, so credential JSONs whose bodies are valid OAuth JSON slipped through; counted metrics had no pinned commands, so grep scope drifted between runs; and no grade floor prevented dimensions from inflating when critical findings were missed.

Three surgical changes:

- **`collect_stats.sh` credential-file sweep.** Path-based scan with two tiers — `HIGH_CONFIDENCE` (filename alone is canonical: `.env` non-sample, SSH private keys, `client_secret*.json`, `service_account*.json`, anything under `.creds/`/`.secrets/`/`.keys/`, kubeconfigs) and `REVIEW` (false-positive-prone: `*.pem`, `*.key`, `*.pfx`, generic `credentials*.json`). Fixture-path exclusions (`tests/`, `__tests__/`, `fixtures/`, `vendor/`, `node_modules/`, `ca-certificates/`) keep legitimate test suites from lighting up the sweep. Review-tier files are classified via silent `grep -q` probes (PEM headers, JSON key-name presence) so **file contents never reach stdout** — the audit skill receives only path + label, not a byte from the body.
- **Quarantine rule + Probe 0 + grade floor in `dimensions.md` Dim 4.** Paths surfaced by the sweep are read-forbidden for the rest of the audit (no `Read`/`cat`/`head`/context-emitting grep); the existing content greps gain mandatory `:(exclude)<path>` pathspecs so a committed `.env` can't leak via `API_KEY=` pattern match; any `real-*` or `binary-keystore-not-inspected` label caps the Secrets dimension at D until the file is rotated and history is filtered.
- **Canonical probes in Dims 3/5/7/10/14.** Exact `rg`/`find` commands with fixed exclusion lists so counted metrics (bare excepts, TODOs, raw-SQL injection, Sentry coverage, over-pinned apps) are reproducible across runs. Closes the scope-drift that produced the 83/51 → 64/40 bare-except count discrepancy.

## Test plan

- [x] `collect_stats.sh` runs under stock `/bin/bash 3.2.57` (smoke test workflow)
- [x] Credential sweep against this marketplace repo → 0 hits (expected baseline)
- [x] Credential sweep against the motivating `data-engineering` monorepo → surfaces `.creds/client_secret_*.json` with label `real-oauth-client-secret`, which the v0.4.1 audit had missed
- [x] Over-pinned-deps canonical probe against `data-engineering` → surfaces both apps the older audit flagged (`professional_metasfresh_crawler`, `professional_hubspot_metasfresh_sync`), plus other apps the newer v0.4.1 audit had also missed
- [x] New CI leak-prevention fixture: seeds seven sentinel-bearing secrets (OAuth JSON, `.env`, SSH key, PEM private key, PEM cert, GCP service-account JSON, fixture-dir key) and asserts *none* of the sentinels appear in the script's stdout or persisted output, while *all* expected paths and classification labels do
- [x] YAML lint of the updated workflow
- [ ] After merge: tag as `codebase-audit-v0.5.0`, publish GitHub release from the CHANGELOG entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)